### PR TITLE
Allow auto-matting feature to be based on image aspect ratio

### DIFF
--- a/picframe/config/configuration_example.yaml
+++ b/picframe/config/configuration_example.yaml
@@ -23,13 +23,8 @@ viewer:
   display_h: null                         # height of display surface
   use_glx: False                          # default=False. Set to True on linux with xserver running
 
-  mat_images: True                        # default=True, Display images on an automatically generated background mat. False, no automatic image matting.
-  mat_portraits_only: False               # default=False, use background mat only for portraits 
-  mat_type: None                          # default=None, The mat type. One of 'float', 'float_polaroid', 'float_color_wrap', 'single_bevel', 'double_bevel', or 'double_flat' (see auto_select_mat_type)
-  outer_mat_color: None                   # default=None, Color of the outer mat as an RGB tuple (see auto_outer_mat_color)
-  inner_mat_color: None                   # default=None, Color of the inner mat as an RGB tuple (see auto_inner_mat_color)
-
-  mat_type: null                          # default=None, A string containing the mat types to choose from when matting images. It can consist of any or
+  mat_images: 0.01                        # default=0.01, True, automatically mat all images. False, don't automatically mat any images. Real value, auto-mat all images with aspect ratio difference > than value
+  mat_type: null                          # default=null, A string containing the mat types to choose from when matting images. It can consist of any or
                                           # all of 'float float_polaroid single_bevel double_bevel double_flat' (null or '' will use all mat types)
   outer_mat_color: null                   # default=null, Color of the outer mat as an RGB list. null will auto-select a reasonable color based on the image.
   inner_mat_color: null                   # default=null, Color of the inner mat as an RGB list. null will auto-select a reasonable color based on the image.

--- a/picframe/model.py
+++ b/picframe/model.py
@@ -18,8 +18,8 @@ DEFAULT_CONFIG = {
         'background': [0.2, 0.2, 0.3, 1.0],
         'blend_type': "blend", # {"blend":0.0, "burn":1.0, "bump":2.0}
 
-        'font_file': '~/picframe_data/data/fonts/NotoSans-Regular.ttf', 
-        'shader': '~/picframe_data/data/shaders/blend_new', 
+        'font_file': '~/picframe_data/data/fonts/NotoSans-Regular.ttf',
+        'shader': '~/picframe_data/data/shaders/blend_new',
         'show_text_fm': '%b %d, %Y',
         'show_text_tm': 20.0,
         'show_text_sz': 40,
@@ -35,7 +35,6 @@ DEFAULT_CONFIG = {
         'use_glx': False,                          # default=False. Set to True on linux with xserver running
         'test_key': 'test_value',
         'mat_images': True,
-        'mat_portraits_only': False,
         'mat_type': None,
         'outer_mat_color': None,
         'inner_mat_color': None,
@@ -47,13 +46,13 @@ DEFAULT_CONFIG = {
     },
     'model': {
 
-        'pic_dir': '~/Pictures', 
+        'pic_dir': '~/Pictures',
         'no_files_img': '~/picframe_data/data/no_pictures.jpg',
-        'subdirectory': '', 
-        'recent_n': 3, 
-        'reshuffle_num': 1, 
-        'time_delay': 200.0, 
-        'fade_time': 10.0, 
+        'subdirectory': '',
+        'recent_n': 3,
+        'reshuffle_num': 1,
+        'time_delay': 200.0,
+        'fade_time': 10.0,
         'shuffle': True,
         'image_attr': ['PICFRAME GPS'],                          # image attributes send by MQTT, Keys are taken from exifread library, 'PICFRAME GPS' is special to retrieve GPS lon/lat
         'load_geoloc': True,


### PR DESCRIPTION
- Change config option "mat_images" to support True/False/Real
  If real, it represents an aspect ratio tolerance for auto-matting
- Add logic to support aspect-based activation of auto-matting feature
- Removed the "mat_portraits_only" config option and associated code
- Added a few helper methods to viewer_display.py