### PR TITLE
Issue 44 - Reduce text scrim height and opacity

### DIFF
--- a/picframe/viewer_display.py
+++ b/picframe/viewer_display.py
@@ -373,9 +373,9 @@ class ViewerDisplay:
                                 space=0.02, colour=(1.0, 1.0, 1.0, 1.0), justify=justify)
             self.__text.add_text_block(block)
             self.__textblocks.append(block)
-        bkg_ht = self.__display.height // 3
+        bkg_ht = self.__display.height // 4
         text_bkg_array = np.zeros((bkg_ht, 1, 4), dtype=np.uint8)
-        text_bkg_array[:,:,3] = np.linspace(0, 170, bkg_ht).reshape(-1, 1)
+        text_bkg_array[:,:,3] = np.linspace(0, 120, bkg_ht).reshape(-1, 1)
         text_bkg_tex = pi3d.Texture(text_bkg_array, blend=True, mipmap=False, free_after_load=True)
 
         back_shader = pi3d.Shader("uv_flat")


### PR DESCRIPTION
- Reduced text scrim height from 1/3 to 1/4 of screen height
- Changed maximum opacity of gradient from 170 to 120. Note, it's still
  possible to read text on 100% white background with these settings.