### PR TITLE
Issue 62 - Independent control of mat texture

### DIFF
--- a/picframe/config/configuration_example.yaml
+++ b/picframe/config/configuration_example.yaml
@@ -32,7 +32,8 @@ viewer:
   inner_mat_color: null                   # default=null, Color of the inner mat as an RGB list. null will auto-select a reasonable color based on the image.
   outer_mat_border: 75                    # default=75, Minimum outer mat border in pixels
   inner_mat_border: 40                    # default=40, Minimum inner mat border in pixels (for styles that use it)
-  use_mat_texture: True                   # default=True, True uses a mat texture. False creates a solid color mat
+  outer_mat_use_texture: True             # default=True, True uses a texture for the outer mat. False creates a solid-color outer mat.
+  inner_mat_use_texture: False            # default=False, True uses a texture for the inner mat. False creates a solid-color inner mat.
   mat_resource_folder: "~/picframe_data/data/mat" # Folder containing mat image files
 
   codepoints: "1234567890AÄÀÆÅÃBCÇDÈÉÊEËFGHIÏÍJKLMNÑOÓÖÔŌØPQRSTUÚÙÜVWXYZaáàãæåäbcçdeéèêëfghiíïjklmnñoóôōøöpqrsßtuúüvwxyz., _-+*()&/`´'•" # limit to 121 ie 11x11 grid_size

--- a/picframe/model.py
+++ b/picframe/model.py
@@ -41,7 +41,8 @@ DEFAULT_CONFIG = {
         'inner_mat_color': None,
         'outer_mat_border': 75,
         'inner_mat_border': 40,
-        'use_mat_texture': True,
+        'inner_mat_use_texture': False,
+        'outer_mat_use_texture': True,
         'mat_resource_folder': '~/picframe_data/data/mat',
         'codepoints': "1234567890AÄÀÆÅÃBCÇDÈÉÊEËFGHIÏÍJKLMNÑOÓÖÔŌØPQRSTUÚÙÜVWXYZaáàãæåäbcçdeéèêëfghiíïjklmnñoóôōøöpqrsßtuúüvwxyz., _-+*()&/`´'•" # limit to 121 ie 11x11 grid_size
     },

--- a/picframe/viewer_display.py
+++ b/picframe/viewer_display.py
@@ -42,7 +42,8 @@ class ViewerDisplay:
         self.__inner_mat_color = config['inner_mat_color']
         self.__outer_mat_border = config['outer_mat_border']
         self.__inner_mat_border = config['inner_mat_border']
-        self.__use_mat_texture = config['use_mat_texture']
+        self.__outer_mat_use_texture = config['outer_mat_use_texture']
+        self.__inner_mat_use_texture = config['inner_mat_use_texture']
         self.__mat_resource_folder = os.path.expanduser(config['mat_resource_folder'])
 
         self.__fps = config['fps']
@@ -252,7 +253,8 @@ class ViewerDisplay:
                     inner_mat_color = self.__inner_mat_color,
                     outer_mat_border = self.__outer_mat_border,
                     inner_mat_border = self.__inner_mat_border,
-                    use_mat_texture = self.__use_mat_texture)
+                    outer_mat_use_texture = self.__outer_mat_use_texture,
+                    inner_mat_use_texture = self.__inner_mat_use_texture)
 
             # Load the image(s) and correct their orientation as necessary
             if pics[0]:


### PR DESCRIPTION
- Allow the use of a texture on the inner and outer mats to be
  controlled independently. By default, the outer mat is textured
  and the inner mat is not textured.
- Cleaned up textured mat generation code

Currently, it's possible to control whether the auto-generated mats use a texture or just a solid color. However, if the texture is active, it's used for both the inner and outer mats (for those styles that have both). This PR allows the use of the mat texture to be controlled independently for both the inner and outer mats using the new `outer_mat_use_texture` and `inner_mat_use_texture` configuration properties.