### PR TITLE
Fix issue 115, unable to toggle directory overlay via MQTT

### DIFF
--- a/picframe/interface_mqtt.py
+++ b/picframe/interface_mqtt.py
@@ -10,14 +10,14 @@ from picframe import __version__
 
 class InterfaceMQTT:
     """MQTT interface of picframe.
-    
+
     This interface interacts via mqtt with the user to steer the image display.
 
     Attributes
     ----------
-    controller : Controler 
+    controller : Controler
         Controller for picframe
-   
+
 
     Methods
     -------
@@ -33,20 +33,20 @@ class InterfaceMQTT:
             self.__client = mqtt.Client(client_id = device_id, clean_session=True)
             login = mqtt_config['login']
             password = mqtt_config['password']
-            self.__client.username_pw_set(login, password) 
+            self.__client.username_pw_set(login, password)
             tls = mqtt_config['tls']
             if tls:
                 self.__client.tls_set(tls)
             server = mqtt_config['server']
             port = mqtt_config['port']
-            self.__client.connect(server, port, 60) 
+            self.__client.connect(server, port, 60)
             self.__client.will_set("homeassistant/switch/" + mqtt_config['device_id'] + "/available", "offline", qos=0, retain=True)
             self.__client.on_connect = self.on_connect
             self.__client.on_message = self.on_message
             self.__device_id = mqtt_config['device_id']
         except Exception as e:
             self.__logger.info("MQTT not set up because of: {}".format(e))
-    
+
     def start(self):
         try:
             self.__controller.publish_state = self.publish_state
@@ -64,8 +64,8 @@ class InterfaceMQTT:
 
     def on_connect(self, client, userdata, flags, rc):
         if rc != 0:
-            self.__logger.warning("Can't connect with mqtt broker. Reason = {0}".format(rc))   
-            return 
+            self.__logger.warning("Can't connect with mqtt broker. Reason = {0}".format(rc))
+            return
         self.__logger.info('Connected with mqtt broker')
 
         sensor_topic_head = "homeassistant/sensor/" + self.__device_id
@@ -153,20 +153,20 @@ class InterfaceMQTT:
                                      "avty_t": available_topic,
                                      "uniq_id": self.__device_id + topic,
                                      "dev": {
-                                        "ids": [self.__device_id], 
-                                        "name": self.__device_id, 
-                                        "mdl": "PictureFrame", 
-                                        "sw": __version__, 
+                                        "ids": [self.__device_id],
+                                        "name": self.__device_id,
+                                        "mdl": "PictureFrame",
+                                        "sw": __version__,
                                         "mf": "pi3d PictureFrame project"}})
-      
+
         client.subscribe(command_topic , qos=0)
         client.publish(config_topic, config_payload, qos=0, retain=True)
         client.publish(state_topic, "ON" if is_on else "OFF", qos=0, retain=True)
 
     def on_message(self, client, userdata, message):
-        msg = message.payload.decode("utf-8") 
+        msg = message.payload.decode("utf-8")
         switch_topic_head = "homeassistant/switch/" + self.__device_id
-       
+
         ###### switches ######
         # display
         if message.topic == switch_topic_head + "_display/set":
@@ -247,7 +247,7 @@ class InterfaceMQTT:
         elif message.topic == switch_topic_head + "_directory_toggle/set":
             state_topic = switch_topic_head + "_directory_toggle/state"
             if msg in ("ON", "OFF"):
-                self.__controller.set_show_text("directory", msg)
+                self.__controller.set_show_text("folder", msg)
                 client.publish(state_topic, msg, retain=True)
         # text_off
         elif message.topic == switch_topic_head + "_text_off/set":
@@ -327,7 +327,7 @@ class InterfaceMQTT:
         dir_attr = {}
         dir_attr['directories'] = dir_list
         # image counter sensor
-        state_payload["image_counter"] = str(self.__controller.get_number_of_files()) 
+        state_payload["image_counter"] = str(self.__controller.get_number_of_files())
         # image sensor
         _, tail = os.path.split(image)
         state_payload["image"] = tail


### PR DESCRIPTION
- Fix broken MQTT directory overlay toggle by using key "folder" instead
  of "directory" in the call to __controller.set_show_text().