### PR TITLE
Digital clock overlay

### DIFF
--- a/picframe/config/configuration_example.yaml
+++ b/picframe/config/configuration_example.yaml
@@ -34,6 +34,9 @@ viewer:
   mat_resource_folder: "~/picframe_data/data/mat" # Folder containing mat image files
 
   show_clock: False                       # default=False, True shows clock overlay. False does not show clock overlay
+  clock_justify: "R"                      # default="R", clock justification L, C, or R
+  clock_text_sz: 120                      # default=120, clock character size
+  clock_format: "%I:%M"                   # default="%I:%M", strftime format for clock string
 
 model:
   pic_dir: "~/Pictures"                   # default="~/Pictures", root folder for images

--- a/picframe/config/configuration_example.yaml
+++ b/picframe/config/configuration_example.yaml
@@ -33,6 +33,8 @@ viewer:
   inner_mat_use_texture: False            # default=False, True uses a texture for the inner mat. False creates a solid-color inner mat.
   mat_resource_folder: "~/picframe_data/data/mat" # Folder containing mat image files
 
+  show_clock: False                       # default=False, True shows clock overlay. False does not show clock overlay
+
 model:
   pic_dir: "~/Pictures"                   # default="~/Pictures", root folder for images
   deleted_pictures: "~/DeletedPictures"   # move deleted pictures here

--- a/picframe/controller.py
+++ b/picframe/controller.py
@@ -14,16 +14,16 @@ def make_date(txt):
 
 class Controller:
     """Controller of picframe.
-    
+
     This controller interacts via mqtt with the user to steer the image display.
 
     Attributes
     ----------
-    model : Model 
+    model : Model
         model of picframe containing config and business logic
     viewer : ViewerDisplay
         viewer of picframe representing the display
-   
+
 
     Methods
     -------
@@ -148,6 +148,14 @@ class Controller:
     @display_is_on.setter
     def display_is_on(self, on_off):
         self.__viewer.display_is_on = on_off
+
+    @property
+    def clock_is_on(self):
+        return self.__viewer.clock_is_on
+
+    @clock_is_on.setter
+    def clock_is_on(self, on_off):
+        self.__viewer.clock_is_on = on_off
 
     @property
     def shuffle(self):
@@ -309,7 +317,7 @@ class Controller:
             time.sleep(0.05) # block until main loop has stopped
         self.__model.stop_image_chache() # close db tidily (blocks till closed)
         self.__viewer.slideshow_stop() # do this last
-    
+
     def __signal_handler(self, sig, frame):
         print('You pressed Ctrl-c!')
         self.__shutdown_complete = True

--- a/picframe/interface_mqtt.py
+++ b/picframe/interface_mqtt.py
@@ -108,6 +108,8 @@ class InterfaceMQTT:
         self.__setup_switch(client, switch_topic_head, "_text_off", "mdi:badge-account-horizontal-outline", available_topic)
         self.__setup_switch(client, switch_topic_head, "_display", "mdi:panorama", available_topic,
                             self.__controller.display_is_on)
+        self.__setup_switch(client, switch_topic_head, "_clock", "mdi-clock-outline", available_topic,
+                            self.__controller.clock_is_on)
         self.__setup_switch(client, switch_topic_head, "_shuffle", "mdi:shuffle-variant", available_topic,
                             self.__controller.shuffle)
         self.__setup_switch(client, switch_topic_head, "_paused", "mdi:pause", available_topic,
@@ -176,6 +178,15 @@ class InterfaceMQTT:
                 client.publish(state_topic, "ON", retain=True)
             elif msg == "OFF":
                 self.__controller.display_is_on = False
+                client.publish(state_topic, "OFF", retain=True)
+        # clock
+        if message.topic == switch_topic_head + "_clock/set":
+            state_topic = switch_topic_head + "_clock/state"
+            if msg == "ON":
+                self.__controller.clock_is_on = True
+                client.publish(state_topic, "ON", retain=True)
+            elif msg == "OFF":
+                self.__controller.clock_is_on = False
                 client.publish(state_topic, "OFF", retain=True)
         # shuffle
         elif message.topic == switch_topic_head + "_shuffle/set":

--- a/picframe/model.py
+++ b/picframe/model.py
@@ -43,6 +43,7 @@ DEFAULT_CONFIG = {
         'inner_mat_use_texture': False,
         'outer_mat_use_texture': True,
         'mat_resource_folder': '~/picframe_data/data/mat',
+        'show_clock': False,
         #'codepoints': "1234567890AÄÀÆÅÃBCÇDÈÉÊEËFGHIÏÍJKLMNÑOÓÖÔŌØPQRSTUÚÙÜVWXYZaáàãæåäbcçdeéèêëfghiíïjklmnñoóôōøöpqrsßtuúüvwxyz., _-+*()&/`´'•" # limit to 121 ie 11x11 grid_size
     },
     'model': {

--- a/picframe/model.py
+++ b/picframe/model.py
@@ -44,6 +44,9 @@ DEFAULT_CONFIG = {
         'outer_mat_use_texture': True,
         'mat_resource_folder': '~/picframe_data/data/mat',
         'show_clock': False,
+        'clock_justify': "R",
+        'clock_text_sz': 120,
+        'clock_format': "%I:%M",
         #'codepoints': "1234567890AÄÀÆÅÃBCÇDÈÉÊEËFGHIÏÍJKLMNÑOÓÖÔŌØPQRSTUÚÙÜVWXYZaáàãæåäbcçdeéèêëfghiíïjklmnñoóôōøöpqrsßtuúüvwxyz., _-+*()&/`´'•" # limit to 121 ie 11x11 grid_size
     },
     'model': {


### PR DESCRIPTION
- Adds an optional digital clock overlay to the frame
- New clock configuration options (and default values)
  - `show_clock`: `False`
  - `clock_justify`: `R`
  - `clock_text_sz`: `120`
  - `clock_format`: `%I:%M`
- The clock's visibility can be toggled ON/OFF via MQTT using
  - Publish: `homeassistant/switch/picframe_clock/set`, `ON` | `OFF`
  - Subscribe: `homeassistant/switch/picframe_clock/state`