### PR TITLE
Fix issue #144, older portrait images inside recent_n window

### DIFF
--- a/picframe/image_cache.py
+++ b/picframe/image_cache.py
@@ -123,13 +123,20 @@ class ImageCache:
                                         """.format(where_clause, sort_clause)
                 pair_list = cursor.execute(sql).fetchall()
                 newlist = []
+                skip_portrait_slot = False
                 for i in range(len(full_list)):
                     if full_list[i][0] != -1:
                         newlist.append(full_list[i])
+                    elif skip_portrait_slot:
+                        skip_portrait_slot = False
+                        continue
                     elif pair_list:
                         elem = pair_list.pop(0)
                         if pair_list:
                             elem += pair_list.pop(0)
+                            # Here, we just doubled-up a set of portrait images.
+                            # Skip the next available "portrait slot" as it's unneeded.
+                            skip_portrait_slot = True
                         newlist.append(elem)
                 return newlist
         except:

--- a/picframe/model.py
+++ b/picframe/model.py
@@ -293,8 +293,10 @@ class Model:
                     time.sleep(0.5)
 
             # If we don't have any files to show, prepare the "no images" image
+            # Also, set the reload_files flag so we'll check for new files on the next pass...
             if self.__number_of_files == 0 or missing_images >= self.__number_of_files:
                 pic1 = Pic(self.__no_files_img, 0, 0)
+                self.__reload_files = True
                 break
 
             # If we've displayed all images...

--- a/picframe/model.py
+++ b/picframe/model.py
@@ -276,33 +276,64 @@ class Model:
         self.__file_index = (self.__file_index - 2) % self.__number_of_files # TODO deleting last image results in ZeroDivisionError
 
     def get_next_file(self):
-        if self.__reload_files:
-            for _i in range(5): # give image_cache chance on first load if a large directory
-                self.__get_files()
-                if self.__number_of_files > 0:
-                    break
-                time.sleep(0.5)
-        if self.__file_index == self.__number_of_files:
-            self.__num_run_through += 1
-            if self.shuffle and self.__num_run_through >= self.get_model_config()['reshuffle_num']:
-                #self.__num_run_through = 0
-                #self.__shuffle_files()
-                self.__reload_files = True
-            self.__file_index = 0
-        if self.__number_of_files == 0:
-            pic = Pic(self.__no_files_img, 0, 0)
-            paired_pic = None
-        else:
+        missing_images = 0
+
+        # loop until we acquire a valid image set
+        while True:
+            pic1 = None
+            pic2 = None
+
+            # Reload the playlist if requested
+            if self.__reload_files:
+                for _i in range(5): # give image_cache chance on first load if a large directory
+                    self.__get_files()
+                    missing_images = 0
+                    if self.__number_of_files > 0:
+                        break
+                    time.sleep(0.5)
+
+            # If we don't have any files to show, prepare the "no images" image
+            if self.__number_of_files == 0 or missing_images >= self.__number_of_files:
+                pic1 = Pic(self.__no_files_img, 0, 0)
+                break
+
+            # If we've displayed all images...
+            #   If it's time to shuffle, set a flag to do so
+            #   Loop back, which will reload and shuffle if necessary
+            if self.__file_index == self.__number_of_files:
+                self.__num_run_through += 1
+                if self.shuffle and self.__num_run_through >= self.get_model_config()['reshuffle_num']:
+                    self.__reload_files = True
+                self.__file_index = 0
+                continue
+
+            # Load the current image set
             file_ids = self.__file_list[self.__file_index]
             pic_row = self.__image_cache.get_file_info(file_ids[0])
-            pic = Pic(**pic_row) if pic_row is not None else None
+            pic1 = Pic(**pic_row) if pic_row is not None else None
             if len(file_ids) == 2:
                 pic_row = self.__image_cache.get_file_info(file_ids[1])
-                paired_pic = Pic(**pic_row) if pic_row is not None else None
-            else:
-                paired_pic = None
-        self.__current_pics = (pic, paired_pic)
-        self.__file_index += 1 # don't wrap back as __file_index == __number_of_files used as trigger above
+                pic2 = Pic(**pic_row) if pic_row is not None else None
+
+            # Verify the images in the selected image set actually exist on disk
+            # Blank out missing references and swap positions if necessary to try and get
+            # a valid image in the first slot.
+            if pic1 and not os.path.isfile(pic1.fname): pic1 = None
+            if pic2 and not os.path.isfile(pic2.fname): pic2 = None
+            if (not pic1 and pic2): pic1, pic2 = pic2, pic1
+
+            # Increment the image index for next time
+            self.__file_index += 1
+
+            # If pic1 is valid here, everything is OK. Break out of the loop and return the set
+            if pic1:
+                break
+
+            # Here, pic1 is undefined. That's a problem. Loop back and get another image set.
+            # Track the number of times we've looped back so we can abort if we don't have *any* images to display
+            missing_images += 1
+
+        self.__current_pics = (pic1, pic2)
         return self.__current_pics
 
     def get_number_of_files(self):


### PR DESCRIPTION
- When buildling the image list returned from query_cache, each time a
   portrait set is paired, the next available "portrait slot" in the processed
   image list should be skipped. Without this, older portrait images will
   be promoted inside the recent_n boundary, even though they don't belong.