### PR TITLE
Fix Issue #153, db threading error

### DIFF
--- a/picframe/controller.py
+++ b/picframe/controller.py
@@ -297,10 +297,7 @@ class Controller:
                             field_name = self.__model.EXIF_TO_FIELD[key]
                             image_attr[key] = pics[0].__dict__[field_name] #TODO nicer using namedtuple for Pic
                     self.publish_state(pics[0].fname, image_attr)
-            if self.__viewer.is_in_transition() == False: # safe to do long running tasks
-                self.__model.pause_looping(True)
-            else:
-                self.__model.pause_looping(False) #TODO only need to set this once rather than every loop
+            self.__model.pause_looping = self.__viewer.is_in_transition()
             (loop_running, skip_image) = self.__viewer.slideshow_is_running(pics, time_delay, fade_time, self.__paused)
             if not loop_running:
                 break

--- a/picframe/image_cache.py
+++ b/picframe/image_cache.py
@@ -27,6 +27,8 @@ class ImageCache:
         # different version from the latest one - should this argument be taken out?
         self.__modified_folders = []
         self.__modified_files = []
+        self.__cached_file_stats = [] # collection shared between threads
+        self.__cached_file_stats_lock = threading.Lock() # lock to manage shared collection
         self.__logger = logging.getLogger("image_cache.ImageCache")
         self.__logger.debug('Creating an instance of ImageCache')
         self.__picture_dir = picture_dir
@@ -52,6 +54,7 @@ class ImageCache:
                 self.update_cache()
                 time.sleep(2.0)
             time.sleep(0.01)
+        self.__update_file_stats() # write any unsaved file stats before closing
         self.__db.commit() # close after update_cache finished for last time
         self.__db.close()
         self.__shutdown_completed = True
@@ -74,6 +77,10 @@ class ImageCache:
         """
 
         self.__logger.debug('Updating cache')
+
+        # Update any cached file stats. This should be really light-weight
+        # so just process any new stats in every pass...
+        self.__update_file_stats()
 
         # If the current collection of updated files is empty, check for disk-based changes
         if not self.__modified_files:
@@ -150,8 +157,7 @@ class ImageCache:
         if row is not None and row['latitude'] is not None and row['longitude'] is not None and row['location'] is None:
             if self.__get_geo_location(row['latitude'], row['longitude']):
                 row = self.__db.execute(sql).fetchone() # description inserted in table
-        # Update the file's displayed stats
-        self.__update_file_stats(file_id)
+        self.__add_file_to_stats_cache(file_id) # Add a record to the file stats cache collection
         return row # NB if select fails (i.e. moved file) will return None
 
     def get_column_names(self):
@@ -159,11 +165,22 @@ class ImageCache:
         rows = self.__db.execute(sql).fetchall()
         return [row['name'] for row in rows]
 
-    def __update_file_stats(self, file_id):
-        # Increment the displayed count for the specified file
-        # Update the last displayed time for the specified file to "now"
-        sql = "UPDATE file SET displayed_count = displayed_count + 1, last_displayed = strftime('%s','now') WHERE file_id = ?"
-        self.__db.execute(sql, (file_id,))
+    def __add_file_to_stats_cache(self, file_id):
+        # This collection is shared between threads, so lock it to update
+        self.__cached_file_stats_lock.acquire()
+        self.__cached_file_stats.append([file_id, time.time()])
+        self.__cached_file_stats_lock.release()
+
+    def __update_file_stats(self):
+        # Process (and drain) the entire collection of cached file stats by storing them in the db
+        # Note, this is likely an empty or very small collection
+        if self.__cached_file_stats:
+            sql = "UPDATE file SET displayed_count = displayed_count + 1, last_displayed = ? WHERE file_id = ?"
+            self.__cached_file_stats_lock.acquire()
+            while self.__cached_file_stats:
+                file_id, timestamp = self.__cached_file_stats.pop()
+                self.__db.execute(sql, (timestamp, file_id))
+            self.__cached_file_stats_lock.release()
 
     def __get_geo_location(self, lat, lon): # TODO periodically check all lat/lon in meta with no location and try again
         location = self.__geo_reverse.get_address(lat, lon)


### PR DESCRIPTION
image_cache.py
- Move database updates for image stats from the main thread into the
  existing image caching thread. The main thread shouldn't update the db.
- Added some shared collection locking for safe thread access.

controller.py
- Also, fix an issue where the model.pause_looping flag was being set
  opposite of what was intended. This had the effect of running some
  database updates while the image was in transition instead of when
  it was idle.