### PR TITLE
Allow hiding of the text background

### DIFF
--- a/picframe/config/configuration_example.yaml
+++ b/picframe/config/configuration_example.yaml
@@ -13,7 +13,7 @@ viewer:
   show_text_sz: 40                        # default=40, text character size
   show_text: "title caption name date folder location"  # default="title caption name date folder location", show text, include combination of words: title, caption name, date, location, folder
   text_justify: "L"                       # text justification L, C or R
-  text_bkg_hgt: 0.25                      # default=0.25 (0.01-1.0), percentage of screen height for text background texture
+  text_bkg_hgt: 0.25                      # default=0.25 (0.0-1.0), percentage of screen height for text background texture
   fit: False                              # default=False, True => scale image so all visible and leave 'gaps'
                                           #                False => crop image so no 'gaps'
   kenburns: False                         # default=False, will set fit->False and blur_edges->False


### PR DESCRIPTION
The commit [a8f0f82](https://github.com/helgeerbe/picframe/commit/a8f0f82ada2deb268588d3cd85ddb2ae6a41f0a7) introduced flexibility to set the height of the text background (`text_bkg_hgt`) to any value in range (0, 1], stopping short of being able to hide the background completely.

This PR extends the range of allowed values to [0, 1] - including 0. When set to 0, the background is not rendered.