### PR TITLE
Add opacity option to text and clock

### DIFF
--- a/picframe/config/configuration_example.yaml
+++ b/picframe/config/configuration_example.yaml
@@ -14,6 +14,7 @@ viewer:
   show_text: "title caption name date folder location"  # default="title caption name date folder location", show text, include combination of words: title, caption name, date, location, folder
   text_justify: "L"                       # text justification L, C or R
   text_bkg_hgt: 0.25                      # default=0.25 (0.0-1.0), percentage of screen height for text background texture
+  text_opacity: 1.0                       # default=1.0 (0.0-1.0), alpha value of text overlay
   fit: False                              # default=False, True => scale image so all visible and leave 'gaps'
                                           #                False => crop image so no 'gaps'
   kenburns: False                         # default=False, will set fit->False and blur_edges->False
@@ -38,6 +39,7 @@ viewer:
   clock_justify: "R"                      # default="R", clock justification L, C, or R
   clock_text_sz: 120                      # default=120, clock character size
   clock_format: "%I:%M"                   # default="%I:%M", strftime format for clock string
+  clock_opacity: 1.0                      # default=1.0 (0.0-1.0), alpha value of clock overlay
 
   menu_text_sz: 40                        # default=40, menu character size
   menu_autohide_tm: 10.0                  # default=10.0, time in seconds to show menu before auto hiding (0 disables auto hiding)

--- a/picframe/model.py
+++ b/picframe/model.py
@@ -26,6 +26,7 @@ DEFAULT_CONFIG = {
         'show_text': "name location",
         'text_justify': 'L',
         'text_bkg_hgt': 0.25,
+        'text_opacity': 1.0,
         'fit': False,
         #'auto_resize': True,
         'kenburns': False,
@@ -48,6 +49,7 @@ DEFAULT_CONFIG = {
         'clock_justify': "R",
         'clock_text_sz': 120,
         'clock_format': "%I:%M",
+        'clock_opacity': 1.0,
         #'codepoints': "1234567890AÄÀÆÅÃBCÇDÈÉÊEËFGHIÏÍJKLMNÑOÓÖÔŌØPQRSTUÚÙÜVWXYZaáàãæåäbcçdeéèêëfghiíïjklmnñoóôōøöpqrsßtuúüvwxyz., _-+*()&/`´'•" # limit to 121 ie 11x11 grid_size
         'menu_text_sz': 40,
         'menu_autohide_tm': 10.0,

--- a/picframe/viewer_display.py
+++ b/picframe/viewer_display.py
@@ -59,6 +59,7 @@ class ViewerDisplay:
         self.__show_text = parse_show_text(config['show_text'])
         self.__text_justify = config['text_justify'].upper()
         self.__text_bkg_hgt = config['text_bkg_hgt'] if 0 <= config['text_bkg_hgt'] <= 1 else 0.25
+        self.__text_opacity = config['text_opacity']
         self.__fit = config['fit']
         #self.__auto_resize = config['auto_resize']
         self.__kenburns = config['kenburns']
@@ -96,6 +97,7 @@ class ViewerDisplay:
         self.__clock_justify = config['clock_justify']
         self.__clock_text_sz = config['clock_text_sz']
         self.__clock_format = config['clock_format']
+        self.__clock_opacity = config['clock_opacity']
         ImageFile.LOAD_TRUNCATED_IMAGES = True # occasional damaged file hangs app
 
     @property
@@ -372,7 +374,8 @@ class ViewerDisplay:
             else:
                 c_rng = self.__display.width * 0.5 - 100 # range for x loc from L to R justified
             block = pi3d.FixedString(self.__font_file, final_string, shadow_radius=3, font_size=self.__show_text_sz,
-                                    shader=self.__flat_shader, justify=self.__text_justify, width=c_rng)
+                                    shader=self.__flat_shader, justify=self.__text_justify, width=c_rng,
+                                    color=(255, 255, 255, int(255 * float(self.__text_opacity))))
             adj_x = (c_rng - block.sprite.width) // 2 # half amount of space outside sprite
             if self.__text_justify == "L":
                 adj_x *= -1
@@ -398,7 +401,8 @@ class ViewerDisplay:
         if current_time != self.__prev_clock_time:
             width = self.__display.width - 50
             self.__clock_overlay = pi3d.FixedString(self.__font_file, current_time, font_size=self.__clock_text_sz,
-                shader=self.__flat_shader, width=width, shadow_radius=3)
+                shader=self.__flat_shader, width=width, shadow_radius=3,
+                color=(255, 255, 255, int(255 * float(self.__clock_opacity))))
             x = (width - self.__clock_overlay.sprite.width) // 2
             if self.__clock_justify == "L":
                 x *= -1


### PR DESCRIPTION
Whilst it is possible to adjust the brightness of the overall image in response to changing lux I found the bright white of the clock and image text can be a bit overpowering - this patch exposes the ImageColor alpha value of the two text overlays so they can be adjusted in the config file and reduce the contrast.

This is the simplest version of the idea, I was considering a 0-100% proportional value and possibly enabling the value being adjusted using mqtt but thought starting simple would be best.