### PR TITLE
Introduce geo_suppress_list to omit strings from location text

### DIFF
--- a/picframe/config/configuration_example.yaml
+++ b/picframe/config/configuration_example.yaml
@@ -41,6 +41,7 @@ viewer:
 
   menu_text_sz: 40                        # default=40, menu character size
   menu_autohide_tm: 10.0                  # default=10.0, time in seconds to show menu before auto hiding (0 disables auto hiding)
+  geo_suppress_list: [],                  # default=None, substrings to remove from the location text
 
 model:
   pic_dir: "~/Pictures"                   # default="~/Pictures", root folder for images

--- a/picframe/model.py
+++ b/picframe/model.py
@@ -51,6 +51,7 @@ DEFAULT_CONFIG = {
         #'codepoints': "1234567890AÄÀÆÅÃBCÇDÈÉÊEËFGHIÏÍJKLMNÑOÓÖÔŌØPQRSTUÚÙÜVWXYZaáàãæåäbcçdeéèêëfghiíïjklmnñoóôōøöpqrsßtuúüvwxyz., _-+*()&/`´'•" # limit to 121 ie 11x11 grid_size
         'menu_text_sz': 40,
         'menu_autohide_tm': 10.0,
+        'geo_suppress_list': [],
     },
     'model': {
 

--- a/picframe/viewer_display.py
+++ b/picframe/viewer_display.py
@@ -60,6 +60,7 @@ class ViewerDisplay:
         self.__text_justify = config['text_justify'].upper()
         self.__text_bkg_hgt = config['text_bkg_hgt'] if 0 <= config['text_bkg_hgt'] <= 1 else 0.25
         self.__fit = config['fit']
+        self.__geo_suppress_list = config['geo_suppress_list']
         #self.__auto_resize = config['auto_resize']
         self.__kenburns = config['kenburns']
         if self.__kenburns:
@@ -358,7 +359,16 @@ class ViewerDisplay:
                 fdt = time.strftime(self.__show_text_fm, time.localtime(pic.exif_datetime))
                 info_strings.append(fdt)
             if (self.__show_text & 16) == 16 and pic.location is not None: # location
-                info_strings.append(pic.location) #TODO need to sanitize and check longer than 0 for real
+                location = pic.location
+                # search for and remove substrings from the location text
+                if self.__geo_suppress_list is not None:
+                    for part in self.__geo_suppress_list:
+                        location = location.replace(part, "")
+                    # remove any redundant concatination strings once the substrings have been removed
+                    location = location.replace(" ,", "")
+                    # remove any trailing commas or spaces from the location
+                    location = location.strip(", ")
+                info_strings.append(location) #TODO need to sanitize and check longer than 0 for real
             if (self.__show_text & 32) == 32: # folder
                 info_strings.append(os.path.basename(os.path.dirname(pic.fname)))
             if paused:


### PR DESCRIPTION
Allows you to remove text from the location text, for instance when
most of your photos are from one location or the reverse geo results
for a location is extremely verbose.