### PR TITLE
Add option to configure basic authentication for HTTP interface

### DIFF
--- a/src/picframe/config/configuration_example.yaml
+++ b/src/picframe/config/configuration_example.yaml
@@ -105,6 +105,9 @@ http:
   use_http: False                         # default=False. Set True to enable http NB THIS SERVER IS FOR LOCAL NETWORK AND SHOULD NOT BE EXPOSED TO EXTERNAL ACCESS
   path: "~/picframe_data/html"            # path to where html files are located
   port: 9000                              # port used to serve pages by http server < 1024 requires root which is *bad* idea
+  auth: false                             # default=False. Set True if enable basic auth for http
+  username: admin                         # username for basic auth
+  password: null                          # password for basic auth. If set null generate random password in file basic_auth.txt in parent http directory
   use_ssl: False
   keyfile: "path/to/key.pem"              # private-key
   certfile: "path/to/cert.pem"            # server certificate

--- a/src/picframe/controller.py
+++ b/src/picframe/controller.py
@@ -353,11 +353,16 @@ class Controller:
         if self.__http_config['use_http']:
             from picframe import interface_http
             model_config = self.__model.get_model_config()
-            self.__interface_http = interface_http.InterfaceHttp(self,
-                                                                 self.__http_config['path'],
-                                                                 model_config['pic_dir'],
-                                                                 model_config['no_files_img'],
-                                                                 self.__http_config['port'])  # TODO: Implement TLS
+            self.__interface_http = interface_http.InterfaceHttp(
+                                                                    self,
+                                                                    self.__http_config['path'],
+                                                                    model_config['pic_dir'],
+                                                                    model_config['no_files_img'],
+                                                                    self.__http_config['port'],
+                                                                    self.__http_config['auth'],
+                                                                    self.__http_config['username'],
+                                                                    self.__http_config['password'],
+                                                                )  # TODO: Implement TLS
             if self.__http_config['use_ssl']:
                 self.__interface_http.socket = ssl.wrap_socket(
                                                 self.__interface_http.socket,

--- a/src/picframe/interface_http.py
+++ b/src/picframe/interface_http.py
@@ -5,6 +5,7 @@ import os
 import logging
 import json
 import threading
+import base64
 
 try:
     from http.server import BaseHTTPRequestHandler, HTTPServer  # py3
@@ -45,7 +46,33 @@ def heif_to_jpg(fname):
 
 class RequestHandler(BaseHTTPRequestHandler):
 
+    def do_AUTHHEAD(self):
+        if self.server._auth is not None:
+            if self.headers.get("Authorization") == None:
+                self.send_response(401)
+                self.send_header("WWW-Authenticate", 'Basic realm="Restricted"')
+                self.send_header("Content-type", "text/html")
+                self.end_headers()
+                response_message = "Error: No authorization header received. Please provide valid credentials.\n"
+                self.wfile.write(response_message.encode('utf-8'))
+                self.connection.close()
+                return False
+            elif self.headers.get("Authorization") != "Basic " + self.server._auth:
+                self.send_response(403)
+                self.send_header("Content-type", "text/html")
+                self.end_headers()
+                response_message = "Error: Invalid authentication credentials. Access denied.\n"
+                self.wfile.write(response_message.encode('utf-8'))
+                self.connection.close()
+                return False
+        return True
+
     def do_GET(self):  # noqa: C901
+        if not self.do_AUTHHEAD():
+            source_ip = self.client_address[0]
+            log_message = f"Authentication failed for source IP: {source_ip}"
+            self.server._logger.warning(log_message)
+            return
         try:
             path_split = self.path.split("?")
             page_ok = False
@@ -140,7 +167,17 @@ class RequestHandler(BaseHTTPRequestHandler):
 
 
 class InterfaceHttp(HTTPServer):
-    def __init__(self, controller, html_path, pic_dir, no_files_img, port=9000):
+    def __init__(
+            self,
+            controller,
+            html_path,
+            pic_dir,
+            no_files_img,
+            port=9000,
+            auth=False,
+            username=None,
+            password=None,
+        ):
         super(InterfaceHttp, self).__init__(("0.0.0.0", port), RequestHandler)
         # NB name mangling throws a spanner in the works here!!!!!
         # *no* __dunders
@@ -150,6 +187,9 @@ class InterfaceHttp(HTTPServer):
         self._pic_dir = os.path.expanduser(pic_dir)
         self._no_files_img = os.path.expanduser(no_files_img)
         self._html_path = os.path.expanduser(html_path)
+        self._auth = None
+        if auth:
+            self._auth = base64.b64encode(f"{username}:{password}".encode()).decode()
         # TODO check below works with all decorated methods.. seems to work
         controller_class = controller.__class__
         self._setters = [method for method in dir(controller_class)

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -208,6 +208,16 @@ class Model:
         return self.__config['mqtt']
 
     def get_http_config(self):
+        if 'auth' in self.__config['http'] and self.__config['http']['auth'] and self.__config['http']['password'] is None:
+            http_parent = os.path.abspath(os.path.join(self.__config['http']['path'], os.pardir))
+            password_path = os.path.join(http_parent, 'basic_auth.txt')
+            if not os.path.exists(password_path):
+                new_password = self.__generate_random_string(64)
+                with open(password_path, "w") as f:
+                    f.write(new_password)
+            with open(password_path, "r") as f:
+                password = f.read()
+                self.__config['http']['password'] = password
         return self.__config['http']
 
     def get_peripherals_config(self):
@@ -425,3 +435,8 @@ class Model:
         self.__file_index = 0
         self.__num_run_through = 0
         self.__reload_files = False
+
+    def __generate_random_string(self, length):
+        random_bytes = os.urandom(length // 2)
+        random_string = ''.join('{:02x}'.format(ord(chr(byte))) for byte in random_bytes)
+        return random_string


### PR DESCRIPTION
## 📝 MR Description:

This Merge Request introduces a new feature allowing users to configure basic authentication for the HTTP interface. The added option enables users to customize authentication settings according to their security requirements.

## 🔄 Changes introduced by the MR:

- 🛠️ New Configuration Option: Added a new configuration parameter that allows enabling and configuring basic authentication for the HTTP interface.
- 📖 Example configuration update - Updated the documentation to include information about the new feature and configuration details.

## 🎯MR Objective:

The objective of this MR is to empower users to configure basic authentication for the HTTP interface, enhancing the security level of the system.

Please review and approve 😸 