### PR TITLE
Fix ISO value handling

### DIFF
--- a/src/picframe/get_image_meta.py
+++ b/src/picframe/get_image_meta.py
@@ -192,6 +192,9 @@ class GetImageMeta:
                 for iso in iso_keys:
                     val = self.__get_if_exist(iso)
                     if val:
+                        # If ISO is returned as a tuple, take the first element
+                        if type(val) is tuple:
+                            val = val[0]
                         break
             else:
                 val = self.__get_if_exist(key)


### PR DESCRIPTION
- https://github.com/helgeerbe/picframe/issues/370 was caused by an ISO value being returned as a tuple (50,50). Check if we have a tuple and, if so, take only the first element.