### PR TITLE
Force color tuple to contain native Python integer values

### DIFF
--- a/src/picframe/mat_image.py
+++ b/src/picframe/mat_image.py
@@ -305,7 +305,7 @@ class MatImage:
     def __get_outer_mat_color(self, image):
         k = KmeansNp(k=3, max_iterations=10, size=100)
         colors = k.run(image)
-        return tuple(colors[0])
+        return tuple(colors[0].tolist())
 
     def __get_darker_shade(self, rgb_color, fractional_percent=0.5):
         return tuple(map(lambda c: int(c * fractional_percent), rgb_color))


### PR DESCRIPTION
Newer versions (?) of numpy retain the underlying numpy data types (np.uint8 in this case), which breaks the consuming code. Using tolist() forces the result to contain native Python integer values.