### PR TITLE
Add support for 'tags_exclude' to let user specify tags to exclude photos

### DIFF
--- a/src/picframe/config/configuration_example.yaml
+++ b/src/picframe/config/configuration_example.yaml
@@ -98,6 +98,7 @@ model:
   portrait_pairs: False
   location_filter: ""                     # default="" filter clause for image location
   tags_filter: ""                         # default="" filter clause for image tags
+  tags_exclude: ""                        # default="" filter clause for excluding image tags
   log_level: "WARNING"                    # default=WARNING, could beDEBUG, INFO, WARNING, ERROR, CRITICAL
   log_file: ""                            # default="" for debugging set this to the path to a file. NB logging messages will
                                           # appended indefinitely so don't forget this. You will need to tidy it up later

--- a/src/picframe/controller.py
+++ b/src/picframe/controller.py
@@ -283,6 +283,18 @@ class Controller:
         else:
             self.__next_tm = 0
 
+    @property
+    def tags_exclude(self):
+        return self.__model.tags_exclude
+
+    @tags_exclude.setter
+    def tags_exclude(self, val):
+        self.__model.tags_exclude = val
+        if self.__viewer.is_video_playing():
+            self.__viewer.stop_video()
+        else:
+            self.__next_tm = 0
+
     def text_is_on(self, txt_key):
         return self.__viewer.text_is_on(txt_key)
 

--- a/src/picframe/html/index.html
+++ b/src/picframe/html/index.html
@@ -37,6 +37,7 @@
                 "subdirectory": {type:"text", fn:"setter", val:""},
                 "location_filter": {type:"text", fn:"setter", val:""},
                 "tags_filter": {type:"text", fn:"setter", val:""},
+                "tags_exclude": {type:"text", fn:"setter", val:""},
                 "delete": {type:"action", fn:"delete={}", val:false},
                 "purge_files": {type:"action", fn:"purge_files={}", val:false},
                 "stop": {type:"action", fn:"stop={}", val:false},

--- a/src/picframe/interface_http.py
+++ b/src/picframe/interface_http.py
@@ -191,7 +191,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                         for subkey in self.server._setters:
                             message[subkey] = getattr(self.server._controller, subkey)
                     elif key in dir(self.server._controller):
-                        if value != "" or key in ("subdirectory", "location_filter", "tags_filter"):  # parse_qsl can return empty string for value when just querying
+                        if value != "" or key in ("subdirectory", "location_filter", "tags_filter", "tags_exclude"):  # parse_qsl can return empty string for value when just querying
                             lwr_val = value.lower()
                             if lwr_val in ("true", "on", "yes"):  # this only works for simple values *not* json style kwargs # noqa: E501
                                 value = True

--- a/src/picframe/interface_mqtt.py
+++ b/src/picframe/interface_mqtt.py
@@ -211,6 +211,8 @@ class InterfaceMQTT:
                           available_topic, entity_category="config")
         self.__setup_text(client, "tags_filter", "mdi:image-search",
                           available_topic, entity_category="config")
+        self.__setup_text(client, "tags_exclude", "mdi:image-search-outline",
+                          available_topic, entity_category="config")
         self.__setup_sensor(client, "image_counter", "mdi:camera-burst",
                             available_topic, entity_category="diagnostic")
         self.__setup_sensor(client, "image", "mdi:file-image",
@@ -713,6 +715,10 @@ class InterfaceMQTT:
         elif message.topic == self.__device_id + "/tags_filter":
             self.__logger.info("Recieved tags filter: %s", msg)
             self.__controller.tags_filter = msg
+        # tags exclude filter
+        elif message.topic == self.__device_id + "/tags_exclude":
+            self.__logger.info("Recieved tags exclude filter: %s", msg)
+            self.__controller.tags_exclude = msg
 
         # set the flag to purge files from database
         elif message.topic == self.__device_id + "/purge_files":
@@ -781,6 +787,8 @@ class InterfaceMQTT:
         sensor_state_payload["location_filter"] = self.__controller.location_filter
         # tags_filter
         sensor_state_payload["tags_filter"] = self.__controller.tags_filter
+        # tags_exclude
+        sensor_state_payload["tags_exclude"] = self.__controller.tags_exclude
         # number state
         # time_delay
         sensor_state_payload["time_delay"] = self.__controller.time_delay

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -85,6 +85,7 @@ DEFAULT_CONFIG = {
         'log_file': '',
         'location_filter': '',
         'tags_filter': '',
+        'tags_exclude': '',
     },
     'mqtt': {
         'use_mqtt': False,  # Set tue true, to enable mqtt
@@ -210,6 +211,7 @@ class Model:
         self.__where_clauses = {}
         self.location_filter = model_config['location_filter']
         self.tags_filter = model_config['tags_filter']
+        self.tags_exclude = model_config['tags_exclude']
 
     def get_viewer_config(self):
         return self.__config['viewer']
@@ -311,6 +313,22 @@ class Model:
             self.set_where_clause("tags_filter", self.__build_filter(val, "tags"))
         else:
             self.set_where_clause("tags_filter")  # remove from where_clause
+        self.__reload_files = True
+
+    @property
+    def tags_exclude(self):
+        return self.__config['model']['tags_exclude']
+
+    @tags_exclude.setter
+    def tags_exclude(self, val):
+        self.__config['model']['tags_exclude'] = val
+        if len(val) > 0:
+            ftr = self.__build_filter(val, "tags")
+            if ftr:
+                ftr = "(tags IS NULL OR NOT {})".format(ftr)
+            self.set_where_clause("tags_exclude", ftr)
+        else:
+            self.set_where_clause("tags_exclude")  # remove from where_clause
         self.__reload_files = True
 
     def __build_filter(self, val, field):


### PR DESCRIPTION
As a follow up to my [discussion](https://github.com/helgeerbe/picframe/discussions/282) on my need to exclude some photos, I made a simple enhancement to add the support for specifying tags to exclude. This is needed even though the existing 'tags_filter' can take expressions like 'NOT (private OR hidden)' as that would only select photos that have at least some tags, as long as they are not 'private' nor 'hidden'.  With 'tags_exclude' it will show photos that don't have any tags, and of course it will exclude photo that have the matching tags.  Like the 'tags_filter', 'tags_exclude' can be set in the configuration.yaml file, through MQTT, and through HTTP.

## Summary by Sourcery

Add a new tags_exclude filter to allow users to exclude photos by tag across all interfaces

New Features:
- Introduce a tags_exclude property in the model with SQL clause generation to exclude matching and untagged photos

Enhancements:
- Expose tags_exclude setter in the controller to refresh views or stop video playback