### PR TITLE
Enhance xmp processing to support HEIC files tagged with ACDSee Photo Studio on Mac

### DIFF
--- a/src/picframe/get_image_meta.py
+++ b/src/picframe/get_image_meta.py
@@ -95,7 +95,10 @@ class GetImageMeta:
             try:
                 val = self.__find_xmp_key('description', xmp)
                 if val:
-                    val = val['Alt']['li']['text']
+                    if (isinstance(val, dict) and 'Alt' in val and
+                        isinstance(val['Alt'], dict) and 'li' in val['Alt'] and
+                        isinstance(val['Alt']['li'], dict) and 'text' in val['Alt']['li']):
+                        val = val['Alt']['li']['text']
                     if val and isinstance(val, str) and len(val) > 0:
                         self.__tags['IPTC Caption/Abstract'] = val
             except KeyError:
@@ -104,12 +107,22 @@ class GetImageMeta:
             try:
                 val = self.__find_xmp_key('subject', xmp)
                 if val:
-                    val = val['Bag']['li']
-                    if val and isinstance(val, list) and len(val) > 0:
+                    if isinstance(val, dict):
+                        if ('Bag' in val and
+                            isinstance(val['Bag'], dict) and 'li' in val['Bag']):
+                            val = val['Bag']['li']
+                        elif ('Seq' in val and
+                            isinstance(val['Seq'], dict) and 'li' in val['Seq']):
+                            val = val['Seq']['li']
+                    if val:
                         tags = ''
-                        for tag in val:
-                            tags += tag + ","
-                        self.__tags['IPTC Keywords'] = tags
+                        if isinstance(val, list):
+                            for tag in val:
+                                tags += tag + ","
+                        elif isinstance(val, str):
+                            tags = val + ","
+                        if tags:
+                            self.__tags['IPTC Keywords'] = tags
             except KeyError:
                 pass
         except Exception as e:


### PR DESCRIPTION
I use ACDSee Photo Studio on Mac which adds keywords to HEIC files in a way different from what the existing code expects.  I made it to look for ['Seq']['li'] if ['Bag']['li'] doesn't exist when looking for 'subject' in xmp.  I also made the processing of both 'description' and 'subject' more robust to avoid unnecessary warning messages.

## Summary by Sourcery

Enhance XMP metadata parsing to support HEIC files tagged by ACDSee Photo Studio on Mac by adding safer extraction for description fields and a fallback for subject tags.

Enhancements:
- Add type and key checks for the 'description' XMP field to safely extract Alt/li/text values
- Fallback to 'Seq/li' when 'Bag/li' is missing for the 'subject' XMP field and handle both list and single string values
- Validate XMP structure before accessing keys to prevent unnecessary warning messages