### PR TITLE
fix(geo_reverse.py): follow Nominatim polices as enforced now.

### DIFF
--- a/src/picframe/geo_reverse.py
+++ b/src/picframe/geo_reverse.py
@@ -2,9 +2,27 @@ import json
 import urllib.request
 import locale
 import logging
+import time
 
+#
+# Looked into
+# - https://operations.osmfoundation.org/policies/nominatim/
+#
+# Actions:
+#  A. Nominatim wants you to use an application specific User-Agent, so here we are:
+#  B. Enforce the Nominatim timing requirement
+#
 URL = "https://nominatim.openstreetmap.org/reverse?format=geojson&lat={}&lon={}&zoom={}&email={}&accept-language={}"
-
+HEADERS = {
+    # fake? 'User-Agent' : 'Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0',
+    # A. Application agent
+    'User-Agent' : 'Picframe-the-DIY-software patched by InI4',
+    # 'Accept'     : '*/*',
+    # 'Accept-Encoding' : 'gzip, deflate, br, zstd',
+    # 'Accept-Encoding' : 'zstd',
+    # 'Accept-Language' : 'en-US,en;q=0.9'
+}
+MINIMUM_INTERVAL = 2.0 # Actually 1.0 is ok, just to be kind
 
 class GeoReverse:
     def __init__(self, geo_key, zoom=18, key_list=None):
@@ -12,15 +30,26 @@ class GeoReverse:
         self.__geo_key = geo_key
         self.__zoom = zoom
         self.__key_list = key_list
-        self.__geo_locations = {}
         self.__language = locale.getlocale()[0][:2]
+        self.__lastRequest = 0 # FSN properly distance the request
 
     def get_address(self, lat, lon):
+        url = URL.format(lat, lon, self.__zoom, self.__geo_key, self.__language)
+
+        # B. Enforce the Nominatim timing requirement
+        dt = time.time() - self.__lastRequest
+        if dt < MINIMUM_INTERVAL :
+            dt = MINIMUM_INTERVAL - dt
+            self.__logger.warning("Sleep %.3f", dt)
+            time.sleep(dt)
+
         try:
-            with urllib.request.urlopen(URL.format(lat, lon, self.__zoom, self.__geo_key, self.__language),
-                                        timeout=3.0) as req:
+            request = urllib.request.Request(url, headers=HEADERS)
+            with urllib.request.urlopen(request, timeout=30.0) as req:
+                self.__lastRequest = time.time()
                 data = json.loads(req.read().decode())
             adr = data['features'][0]['properties']['address']
+
             # some experimentation might be needed to get a good set of alternatives in key_list
             adr_list = []
             if self.__key_list is not None:
@@ -35,3 +64,4 @@ class GeoReverse:
         except Exception as e:  # TODO return different thing for different exceptions
             self.__logger.error("lat=%f, lon=%f -> %s", lat, lon, e)
             return ""
+


### PR DESCRIPTION
Turns out, Nominatim is lately more strictly enforcing policies concerning access to their free API.
My personal testing instance became locked out from Nominatom, receiving 403 responses.
This patch fixes this.

## Summary by Sourcery

Ensure reverse geocoding requests to Nominatim comply with updated usage policies to avoid being blocked.

Bug Fixes:
- Add an application-specific User-Agent header to Nominatim reverse geocoding requests to satisfy API policy requirements.
- Throttle reverse geocoding calls by enforcing a minimum interval between Nominatim requests to comply with rate limits and prevent 403 responses.

Enhancements:
- Increase the timeout for Nominatim reverse geocoding requests and log sleep intervals before issuing calls.