### PR TITLE
Fix video playback delay caused by show_text_tm

### DIFF
--- a/src/picframe/viewer_display.py
+++ b/src/picframe/viewer_display.py
@@ -706,7 +706,9 @@ class ViewerDisplay:
             self.__in_transition = True  # set __in_transition True a few seconds *before* end of previous slide
         else:  # no transition effect safe to update database, resuffle etc
             self.__in_transition = False
-            if self.__video_path is not None and tm > self.__name_tm:
+            # Videos should start immediately after the fade transition.
+            # show_text_tm only controls the text overlay and must not delay video playback.
+            if self.__video_path is not None and self.__alpha >= 1.0:
                 # start video stream
                 if self.__video_streamer is None or not self.__video_streamer.player_alive():
                     self.__video_streamer = VideoStreamer(


### PR DESCRIPTION
When displaying videos, playback is currently delayed until show_text_tm has expired.

show_text_tm is intended to control the duration of the text overlay for still images, but it also delays the start of video playback.

This change starts videos immediately after the fade transition has completed while keeping the existing text overlay behaviour for still images unchanged.

Tested with:

show_text_tm = 20
fade_time = 1
Photos: text overlay behaviour unchanged.
Videos: playback starts immediately after fade.
Mixed photo/video slideshow works as expected.

## Summary by Sourcery

Bug Fixes:
- Prevent show_text_tm timing for text overlays from delaying the start of video playback in slideshows.