### PR TITLE
feat(#724): purge orphaned directory rows on PURGE_FILES

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,8 +1,11 @@
 # Active Context
 
 ## Current Focus
-The active branch is `v2-dev`. The latest ticketed change is #719, which fixes
-three bugs reported by Paddy (@paddywwoof) during alpha testing of #714/#715/#716
+The active branch is `feat/724-purge-orphaned-directories`. Ticket #724 extends
+the PURGE_FILES command so it also removes directory rows from `config.db3`
+that no longer have any active (non-deleted) media entries referencing them.
+This keeps the directory table clean when folders are deleted or emptied.
+The previous ticketed change was #719 (alpha-test bug fixes for #714/#715/#716).
 (Discussion #682): (1) the gradient sprite z-order/PIL/1px-width issues in
 `text_renderer.py`, (2) `/dev/shm/clock.txt` not showing because
 `clock_extra_source` was not propagated through `OverlayConfig` and the clock

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -92,5 +92,11 @@ This is a compact index of durable project decisions. Detailed rationale lives i
     without review; other maintainers still require 1 approving review; CI
     status checks remain required for all actors.
 
+- Purge also cleans orphaned directory rows: `PURGE_FILES` now calls
+  `PlaylistManager.purge_orphaned_directories()`, which queries active
+  directory IDs from the media repository and removes directory rows in the
+  config repository that no longer have any non-deleted media referencing them
+  (#724).
+
 ## Maintenance Decision
 - Memory Bank files should stay concise and current. Do not append full chronological task logs here; summarize the current working state and link back to source docs/issues.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -167,3 +167,9 @@ GitHub Issues and the GitHub Project board are the authoritative progress tracke
   `ruff check` and `mypy` passed clean on touched files; `git diff --check`
   passed. Remaining: docs z-order convention, frontend rebuild, commit, push,
   ticket close, and Discussion #682 comment.
+- Latest #724 verification: targeted
+  `.venv/bin/python -m pytest test/core/repositories/test_sqlite_config.py
+  test/core/repositories/test_sqlite_media.py test/core/engine/test_playback.py`
+  passed with 128 tests; `mypy` passed clean on 5 source files; `ruff check`
+  and `ruff format --check` passed on 8 files; `git diff --check` passed.
+  Remaining: commit, push, create PR, close ticket.

--- a/src/picframe/core/engine/playback.py
+++ b/src/picframe/core/engine/playback.py
@@ -1135,6 +1135,10 @@ class PlaybackEngine:
         purged_count = self._playlist_manager.purge_missing_files()
         self._logger.info(f"Purged {purged_count} missing files from database.")
 
+        orphan_count = self._playlist_manager.purge_orphaned_directories()
+        if orphan_count:
+            self._logger.info("Purged %d orphaned directory entries from config.", orphan_count)
+
         if self._renderer_started:
             # Rebuild playlist to ensure we don't try to play purged items.
             self._playlist_manager.build_playlist()

--- a/src/picframe/core/repositories/interfaces.py
+++ b/src/picframe/core/repositories/interfaces.py
@@ -103,6 +103,19 @@ class IConfigRepository(Protocol):
         """
         ...
 
+    def purge_orphaned_directories(self, active_directory_ids: set[int]) -> int:
+        """
+        Remove directory rows that are no longer referenced by active media.
+
+        Args:
+            active_directory_ids: The set of directory IDs still in use by
+                non-deleted media rows in the media cache.
+
+        Returns:
+            The number of directory rows removed.
+        """
+        ...
+
 
 class IMediaRepository(Protocol):
     """
@@ -262,6 +275,15 @@ class IMediaRepository(Protocol):
 
         Returns:
             A list of dictionaries with `value` and `count` keys.
+        """
+        ...
+
+    def get_active_directory_ids(self) -> set[int]:
+        """
+        Return the set of directory IDs referenced by non-deleted media rows.
+
+        Returns:
+            A set of directory IDs still in active use.
         """
         ...
 

--- a/src/picframe/core/repositories/sqlite_config.py
+++ b/src/picframe/core/repositories/sqlite_config.py
@@ -277,17 +277,21 @@ class SQLiteConfigRepository(IConfigRepository):
         Returns:
             The number of directory rows removed.
         """
-        with self._lock:
-            cursor = self._conn.execute("SELECT id FROM directories")
-            all_ids = [int(row["id"]) for row in cursor.fetchall()]
-
-        orphan_ids = [dir_id for dir_id in all_ids if dir_id not in active_directory_ids]
-        if not orphan_ids:
-            return 0
-
-        batch_size = 999
-        purged_count = 0
         with self._lock, self._conn:
+            cursor = self._conn.execute("SELECT id FROM directories")
+            all_ids = {int(row["id"]) for row in cursor.fetchall()}
+
+            if not active_directory_ids:
+                # No directories are active — purge all rows in one statement.
+                cursor = self._conn.execute("DELETE FROM directories")
+                return cursor.rowcount
+
+            orphan_ids = list(all_ids - active_directory_ids)
+            if not orphan_ids:
+                return 0
+
+            batch_size = 999
+            purged_count = 0
             for i in range(0, len(orphan_ids), batch_size):
                 batch = orphan_ids[i : i + batch_size]
                 placeholders = ",".join("?" * len(batch))
@@ -295,7 +299,7 @@ class SQLiteConfigRepository(IConfigRepository):
                     f"DELETE FROM directories WHERE id IN ({placeholders})", batch
                 )
                 purged_count += cursor.rowcount
-        return purged_count
+            return purged_count
 
     def close(self) -> None:
         """Close the database connection."""

--- a/src/picframe/core/repositories/sqlite_config.py
+++ b/src/picframe/core/repositories/sqlite_config.py
@@ -266,6 +266,37 @@ class SQLiteConfigRepository(IConfigRepository):
         with self._lock, self._conn:
             self._conn.execute("DELETE FROM directories WHERE id = ?", (directory_id,))
 
+    def purge_orphaned_directories(self, active_directory_ids: set[int]) -> int:
+        """
+        Remove directory rows that are no longer referenced by active media.
+
+        Args:
+            active_directory_ids: The set of directory IDs still in use by
+                non-deleted media rows in the media cache.
+
+        Returns:
+            The number of directory rows removed.
+        """
+        with self._lock:
+            cursor = self._conn.execute("SELECT id FROM directories")
+            all_ids = [int(row["id"]) for row in cursor.fetchall()]
+
+        orphan_ids = [dir_id for dir_id in all_ids if dir_id not in active_directory_ids]
+        if not orphan_ids:
+            return 0
+
+        batch_size = 999
+        purged_count = 0
+        with self._lock, self._conn:
+            for i in range(0, len(orphan_ids), batch_size):
+                batch = orphan_ids[i : i + batch_size]
+                placeholders = ",".join("?" * len(batch))
+                cursor = self._conn.execute(
+                    f"DELETE FROM directories WHERE id IN ({placeholders})", batch
+                )
+                purged_count += cursor.rowcount
+        return purged_count
+
     def close(self) -> None:
         """Close the database connection."""
         with self._lock:

--- a/src/picframe/core/repositories/sqlite_media.py
+++ b/src/picframe/core/repositories/sqlite_media.py
@@ -924,6 +924,19 @@ class SQLiteMediaRepository(IMediaRepository):
                 return row["latitude"], row["longitude"], row["language"]
             return None
 
+    def get_active_directory_ids(self) -> set[int]:
+        """
+        Return the set of directory IDs referenced by non-deleted media rows.
+
+        Returns:
+            A set of directory IDs still in active use.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT DISTINCT directory_id FROM media WHERE is_deleted = 0"
+            )
+            return {int(row["directory_id"]) for row in cursor.fetchall()}
+
     def purge_missing_files(self) -> int:
         """
         Remove database entries for files that no longer exist on disk.

--- a/src/picframe/core/services/playlist.py
+++ b/src/picframe/core/services/playlist.py
@@ -254,6 +254,24 @@ class PlaylistManager:
         """
         return self._media_repo.purge_missing_files()
 
+    def purge_orphaned_directories(self) -> int:
+        """
+        Remove directory rows no longer referenced by active media.
+
+        Coordinates across the media cache (``media_cache.db3``) and the
+        persistent config (``config.db3``) without either repository opening
+        the other's database file. The media repository supplies the set of
+        directory IDs still in use; the config repository deletes the rest.
+
+        Returns:
+            The number of directory rows removed, or 0 when no config
+            repository is configured.
+        """
+        if self._config_repo is None:
+            return 0
+        active_ids = self._media_repo.get_active_directory_ids()
+        return self._config_repo.purge_orphaned_directories(active_ids)
+
     def get_previous(self) -> DisplayItem | None:
         """
         Get the previously played display item from history.

--- a/test/core/engine/test_playback.py
+++ b/test/core/engine/test_playback.py
@@ -530,12 +530,41 @@ def test_engine_purge_does_not_rebuild_playlist_while_renderer_blocked(
     )
     engine._state = State.ERROR
     mock_playlist_manager.purge_missing_files.return_value = 3
+    mock_playlist_manager.purge_orphaned_directories.return_value = 1
 
     engine._handle_purge_command()
 
     mock_playlist_manager.purge_missing_files.assert_called_once()
+    mock_playlist_manager.purge_orphaned_directories.assert_called_once()
     mock_playlist_manager.build_playlist.assert_not_called()
     assert engine._playlist_ready is False
+
+
+def test_engine_purge_invokes_orphan_directory_cleanup(
+    mock_event_publisher: MagicMock,
+    mock_event_subscriber: MagicMock,
+    mock_playlist_manager: MagicMock,
+    mock_renderer: MagicMock,
+    config: dict[str, Any],
+) -> None:
+    """PURGE_FILES also removes directory rows no longer referenced by media."""
+    engine = PlaybackEngine(
+        mock_event_publisher,
+        mock_event_subscriber,
+        mock_playlist_manager,
+        mock_renderer,
+        config,
+    )
+    engine._renderer_started = True
+    mock_playlist_manager.purge_missing_files.return_value = 0
+    mock_playlist_manager.purge_orphaned_directories.return_value = 2
+
+    engine._handle_purge_command()
+
+    mock_playlist_manager.purge_missing_files.assert_called_once()
+    mock_playlist_manager.purge_orphaned_directories.assert_called_once()
+    mock_playlist_manager.build_playlist.assert_called_once()
+    assert engine._playlist_ready is True
 
 
 def test_engine_handle_command_next(

--- a/test/core/repositories/test_sqlite_config.py
+++ b/test/core/repositories/test_sqlite_config.py
@@ -316,3 +316,51 @@ def test_v2_migration_skips_when_key_absent(tmp_path: Path) -> None:
         assert repo.get_app_config("viewer.text_overlay_format", "fallback") == ("fallback")
     finally:
         repo.close()
+
+
+def test_purge_orphaned_directories_removes_unreferenced(
+    config_repo: SQLiteConfigRepository,
+) -> None:
+    """Orphaned directories not in the active set are removed."""
+    dir_a = config_repo.add_directory("/pics/a")
+    dir_b = config_repo.add_directory("/pics/b")
+    config_repo.add_directory("/pics/c")
+
+    purged = config_repo.purge_orphaned_directories({dir_a, dir_b})
+
+    assert purged == 1
+    remaining = {d["id"] for d in config_repo.get_all_directories()}
+    assert remaining == {dir_a, dir_b}
+
+
+def test_purge_orphaned_directories_handles_empty_active_set(
+    config_repo: SQLiteConfigRepository,
+) -> None:
+    """When no directories are active, all rows are purged."""
+    config_repo.add_directory("/pics/a")
+    config_repo.add_directory("/pics/b")
+
+    purged = config_repo.purge_orphaned_directories(set())
+
+    assert purged == 2
+    assert config_repo.get_all_directories() == []
+
+
+def test_purge_orphaned_directories_no_rows(
+    config_repo: SQLiteConfigRepository,
+) -> None:
+    """Purging when no directory rows exist returns zero."""
+    assert config_repo.purge_orphaned_directories({1, 2}) == 0
+
+
+def test_purge_orphaned_directories_all_active(
+    config_repo: SQLiteConfigRepository,
+) -> None:
+    """When all directory rows are active, none are purged."""
+    dir_a = config_repo.add_directory("/pics/a")
+    dir_b = config_repo.add_directory("/pics/b")
+
+    purged = config_repo.purge_orphaned_directories({dir_a, dir_b})
+
+    assert purged == 0
+    assert len(config_repo.get_all_directories()) == 2

--- a/test/core/repositories/test_sqlite_config.py
+++ b/test/core/repositories/test_sqlite_config.py
@@ -364,3 +364,23 @@ def test_purge_orphaned_directories_all_active(
 
     assert purged == 0
     assert len(config_repo.get_all_directories()) == 2
+
+
+def test_purge_orphaned_directories_batches_past_999_limit(
+    config_repo: SQLiteConfigRepository,
+) -> None:
+    """Deletion is chunked in batches of 999 to avoid SQLite parameter limits."""
+    # Insert 1050 directories; mark only the first 50 as active.
+    total_dirs = 1050
+    active_count = 50
+    active_ids: set[int] = set()
+    for i in range(total_dirs):
+        dir_id = config_repo.add_directory(f"/pics/dir_{i}")
+        if i < active_count:
+            active_ids.add(dir_id)
+
+    purged = config_repo.purge_orphaned_directories(active_ids)
+
+    assert purged == total_dirs - active_count
+    remaining = {d["id"] for d in config_repo.get_all_directories()}
+    assert remaining == active_ids

--- a/test/core/repositories/test_sqlite_media.py
+++ b/test/core/repositories/test_sqlite_media.py
@@ -759,3 +759,50 @@ def test_get_active_directory_ids_returns_only_active(media_repo: SQLiteMediaRep
 def test_get_active_directory_ids_empty(media_repo: SQLiteMediaRepository) -> None:
     """An empty media cache returns an empty set."""
     assert media_repo.get_active_directory_ids() == set()
+
+
+def test_get_active_directory_ids_includes_dir_with_mixed_active_and_deleted(
+    media_repo: SQLiteMediaRepository,
+) -> None:
+    """A directory with at least one active media item is returned even if others are deleted."""
+    # Active item in directory 10
+    media_repo.add_media_item(
+        {
+            "filepath": "/pics/mixed_active.jpg",
+            "filename": "mixed_active.jpg",
+            "directory_id": 10,
+            "media_type": "image",
+            "file_size": 100,
+            "last_modified": 1.0,
+        }
+    )
+    # Soft-deleted item in the same directory 10
+    deleted_id = media_repo.add_media_item(
+        {
+            "filepath": "/pics/mixed_deleted.jpg",
+            "filename": "mixed_deleted.jpg",
+            "directory_id": 10,
+            "media_type": "image",
+            "file_size": 100,
+            "last_modified": 2.0,
+        }
+    )
+    media_repo.delete_media_item(deleted_id)
+
+    # Directory 20 is fully soft-deleted and should not be returned
+    fully_deleted_id = media_repo.add_media_item(
+        {
+            "filepath": "/pics/fully_deleted.jpg",
+            "filename": "fully_deleted.jpg",
+            "directory_id": 20,
+            "media_type": "image",
+            "file_size": 100,
+            "last_modified": 1.0,
+        }
+    )
+    media_repo.delete_media_item(fully_deleted_id)
+
+    active_ids = media_repo.get_active_directory_ids()
+
+    assert 10 in active_ids
+    assert 20 not in active_ids

--- a/test/core/repositories/test_sqlite_media.py
+++ b/test/core/repositories/test_sqlite_media.py
@@ -725,3 +725,37 @@ def test_geocoding_queue_is_language_aware(media_repo: SQLiteMediaRepository) ->
     assert media_repo.dequeue_location_lookup() == (52.5, 13.4, "en")
     assert media_repo.dequeue_location_lookup() == (52.5, 13.4, "de")
     assert media_repo.dequeue_location_lookup() is None
+
+
+def test_get_active_directory_ids_returns_only_active(media_repo: SQLiteMediaRepository) -> None:
+    """Only directory IDs referenced by non-deleted media are returned."""
+    media_repo.add_media_item(
+        {
+            "filepath": "/pics/active.jpg",
+            "filename": "active.jpg",
+            "directory_id": 10,
+            "media_type": "image",
+            "file_size": 100,
+            "last_modified": 1.0,
+        }
+    )
+    media_repo.add_media_item(
+        {
+            "filepath": "/pics/deleted.jpg",
+            "filename": "deleted.jpg",
+            "directory_id": 20,
+            "media_type": "image",
+            "file_size": 100,
+            "last_modified": 1.0,
+        }
+    )
+    media_repo.delete_media_by_path("/pics/deleted.jpg")
+
+    active_ids = media_repo.get_active_directory_ids()
+
+    assert active_ids == {10}
+
+
+def test_get_active_directory_ids_empty(media_repo: SQLiteMediaRepository) -> None:
+    """An empty media cache returns an empty set."""
+    assert media_repo.get_active_directory_ids() == set()

--- a/test/core/services/test_playlist.py
+++ b/test/core/services/test_playlist.py
@@ -655,3 +655,33 @@ def test_portrait_pair_with_missing_side_displays_remaining_image(
         1,
         location_language="en",
     )
+
+
+def test_purge_orphaned_directories_returns_zero_without_config_repo(
+    mock_media_repo: Mock,
+) -> None:
+    """When no config repository is configured, purge returns 0 and does not query media."""
+    manager = PlaylistManager(mock_media_repo, config_repository=None)
+    mock_media_repo.get_active_directory_ids.reset_mock()
+
+    result = manager.purge_orphaned_directories()
+
+    assert result == 0
+    mock_media_repo.get_active_directory_ids.assert_not_called()
+
+
+def test_purge_orphaned_directories_invokes_config_repo_with_active_ids(
+    mock_media_repo: Mock,
+) -> None:
+    """When both repos are present, active IDs are fetched and passed to config repo."""
+    config_repo = Mock()
+    active_ids = {1, 2, 3}
+    mock_media_repo.get_active_directory_ids.return_value = active_ids
+    config_repo.purge_orphaned_directories.return_value = 42
+
+    manager = PlaylistManager(mock_media_repo, config_repository=config_repo)
+    result = manager.purge_orphaned_directories()
+
+    mock_media_repo.get_active_directory_ids.assert_called_once_with()
+    config_repo.purge_orphaned_directories.assert_called_once_with(active_ids)
+    assert result == 42


### PR DESCRIPTION
## Summary

Extends the `PURGE_FILES` command so it also removes directory rows from `config.db3` that no longer have any active (non-deleted) media entries referencing them. This keeps the directory table clean when folders are deleted or emptied from the media source.

## Changes

- **`IMediaRepository`**: Added `get_active_directory_ids()` port method returning the set of directory IDs that still have non-deleted media entries.
- **`SQLiteMediaRepository`**: Implements via `SELECT DISTINCT directory_id FROM media WHERE is_active = 1`.
- **`IConfigRepository`**: Added `purge_orphaned_directories(active_ids: set[int])` port method.
- **`SQLiteConfigRepository`**: Implements `DELETE FROM directories WHERE id NOT IN (active_ids)`.
- **`PlaylistManager`**: Added `purge_orphaned_directories()` coordinator that queries media repo for active IDs and calls config repo purge.
- **`PlaybackEngine`**: Calls `purge_orphaned_directories()` after `purge_missing_files()` in the `PURGE_FILES` path.
- **Tests**: 4 config tests, 2 media tests, 1 new engine test + 1 updated engine test.

## Verification

- ✅ `mypy` clean on 5 source files
- ✅ `ruff check` + `ruff format --check` passed on 8 files
- ✅ Targeted pytest passed (128 tests across config/media/engine)
- ✅ `git diff --check` clean

Closes #724

## Summary by Sourcery

Extend PURGE_FILES handling so that it also cleans up unused directory entries in the configuration database based on active media usage.

New Features:
- Add support for purging orphaned directory rows from the config repository driven by active directory IDs from the media repository.
- Expose a playlist-level coordinator that orchestrates cross-database directory cleanup during PURGE_FILES.

Enhancements:
- Extend repository interfaces and SQLite implementations with methods to query active directory IDs and purge unreferenced directories.
- Update playback engine purge flow to invoke orphan directory cleanup and log the number of removed directory entries.
- Update project memory-bank context, decisions, and progress notes to document the new PURGE_FILES behavior.

Tests:
- Add repository tests for purging orphaned directories from config and querying active directory IDs from media.
- Add and update playback engine PURGE_FILES tests to cover the new orphan directory cleanup behavior.