### PR TITLE
fix(metadata): add XMP subject Seq/li fallback for ACDSee Photo Studio on Mac

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,11 +1,12 @@
 # Active Context
 
 ## Current Focus
-The active branch is `feat/724-purge-orphaned-directories`. Ticket #724 extends
-the PURGE_FILES command so it also removes directory rows from `config.db3`
-that no longer have any active (non-deleted) media entries referencing them.
-This keeps the directory table clean when folders are deleted or emptied.
-The previous ticketed change was #719 (alpha-test bug fixes for #714/#715/#716).
+The active branch is `fix/xmp-subject-seq-li-725`. Ticket #725 adds a
+`Seq/li` fallback to XMP subject parsing in
+`ImageMetadataStrategy._get_xmp_data()` so ACDSee Photo Studio on Mac (which
+writes keywords under `Seq/li` instead of the common `Bag/li`) no longer
+silently misses tags from HEIC files. The previous ticketed change was #724
+(purge orphaned directory rows on PURGE_FILES).
 (Discussion #682): (1) the gradient sprite z-order/PIL/1px-width issues in
 `text_renderer.py`, (2) `/dev/shm/clock.txt` not showing because
 `clock_extra_source` was not propagated through `OverlayConfig` and the clock
@@ -15,7 +16,7 @@ to `last_modified` at indexing time. Issues #714/#715/#716 are now fully
 functional after the #719 fixes.
 
 ## Current Repo State
-- Branch: `v2-dev`; #719 is the latest local implementation context.
+- Branch: `fix/xmp-subject-seq-li-725` (rebased from `origin/v2-dev`); #724 is the latest merged context on `v2-dev`.
 - `.Codexrules` is a local instruction file and is ignored by git.
 - The source tree is centered on the next-gen `main.py`, `core`, `api`, and `infrastructure` architecture; broad legacy runtime modules were removed during #678 while reusable helpers such as matting/geocoding remain where still imported.
 

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -97,6 +97,10 @@ This is a compact index of durable project decisions. Detailed rationale lives i
   directory IDs from the media repository and removes directory rows in the
   config repository that no longer have any non-deleted media referencing them
   (#724).
+- XMP subject parsing must accept both Bag/li and Seq/li containers, and
+  handle single-string `li` values as well as lists. ACDSee Photo Studio on
+  Mac writes keywords under Seq/li instead of the common Bag/li; Bag/li
+  remains the preferred path when both are present (#725).
 
 ## Maintenance Decision
 - Memory Bank files should stay concise and current. Do not append full chronological task logs here; summarize the current working state and link back to source docs/issues.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -111,12 +111,24 @@ GitHub Issues and the GitHub Project board are the authoritative progress tracke
   `dev (incl v2-dev)` and `main` rulesets so the owner can self-merge PRs
   without review, while other maintainers still require 1 approving review;
   CI status checks remain required for all actors.
+- Ticket #724 purge orphaned directory rows: `PURGE_FILES` now calls
+  `PlaylistManager.purge_orphaned_directories()`, which queries active
+  directory IDs from the media repository and removes directory rows in the
+  config repository that no longer have any non-deleted media referencing them.
+- Ticket #725 XMP subject Seq/li fallback: `ImageMetadataStrategy._get_xmp_data()`
+  now extracts XMP subject keywords from either Bag/li (common) or Seq/li
+  (ACDSee Photo Studio on Mac) via a new static `_extract_xmp_subject_tags()`
+  helper, and handles both list and single-string `li` values. Tests cover
+  Bag/li list, Seq/li list, Bag/li single string, Seq/li single string,
+  missing-both, and Bag-preferred-over-Seq cases. The fix preserves existing
+  Bag/li behavior as the first-choice path.
 
 ## Current / In Progress
 - Phase 2 Control Plane/UI remains the broad current phase in local documentation; #648 is closed after the playlist-filter and Remote media-selection slice was implemented and verified.
 - Video engine integration remains an active architectural stream: caps-driven hardware discovery, fallback observability, software fallback limits, and Raspberry Pi/labwc validation of the GTK4 handoff behavior.
 - #691 is merged into `v2-dev`, pushed to `origin/v2-dev`, and closed. Additional Raspberry Pi/labwc validation of the handoff behavior remains useful target coverage.
 - #635 remains open for Raspberry Pi manual validation and final closeout decision after implementation verification.
+- #725 XMP subject Seq/li fallback is in progress on branch `fix/xmp-subject-seq-li-725` (rebased from `origin/v2-dev`): helper and tests implemented. Pending: quality gates, commit, force-push to update PR #732, close ticket.
 
 ## Next
 - Continue caps-driven hardware capability discovery in the GStreamer worker, with Pi V4L2 probing enabled before worker startup.
@@ -173,3 +185,8 @@ GitHub Issues and the GitHub Project board are the authoritative progress tracke
   passed with 128 tests; `mypy` passed clean on 5 source files; `ruff check`
   and `ruff format --check` passed on 8 files; `git diff --check` passed.
   Remaining: commit, push, create PR, close ticket.
+- Latest #725 verification: targeted
+  `.venv/bin/python -m pytest test/core/metadata/test_image_strategy.py -v`
+  passed with 14 tests; `mypy` passed clean on 2 source files; `ruff check`
+  and `ruff format --check` passed on 2 files. Remaining: commit, force-push
+  to update PR #732, close ticket.

--- a/src/picframe/core/metadata/image_strategy.py
+++ b/src/picframe/core/metadata/image_strategy.py
@@ -384,6 +384,36 @@ class ImageMetadataStrategy(IMetadataStrategy):
                             return val
         return None
 
+    @staticmethod
+    def _extract_xmp_subject_tags(val: Any) -> str | None:
+        """
+        Extract XMP subject tags from either Bag/li or Seq/li structures.
+
+        ACDSee Photo Studio on Mac writes keywords under Seq/li instead of the
+        more common Bag/li. Single keywords may be stored as a string rather
+        than a list (#725).
+
+        Args:
+            val: The value found under the XMP "subject" key.
+
+        Returns:
+            A comma-joined tag string, or None if no tags could be extracted.
+        """
+        if not (val and isinstance(val, dict)):
+            return None
+
+        # Try Bag/li first (common case), then fall back to Seq/li (ACDSee on Mac)
+        for container_key in ("Bag", "Seq"):
+            container = val.get(container_key)
+            if not (isinstance(container, dict) and "li" in container):
+                continue
+            li_val = container["li"]
+            if isinstance(li_val, list) and len(li_val) > 0:
+                return ", ".join(str(tag) for tag in li_val)
+            if isinstance(li_val, str) and len(li_val) > 0:
+                return li_val
+        return None
+
     def _get_xmp_data(self, filepath: str) -> dict[str, Any]:
         """
         Retrieve XMP tags using PIL.
@@ -418,12 +448,11 @@ class ImageMetadataStrategy(IMetadataStrategy):
                             if text_val and isinstance(text_val, str) and len(text_val) > 0:
                                 xmp_data["caption"] = text_val
 
-                        # tags
+                        # tags — try Bag/li first, fall back to Seq/li for ACDSee on Mac (#725)
                         val = self._find_xmp_key("subject", xmp)
-                        if val and isinstance(val, dict) and "Bag" in val and "li" in val["Bag"]:
-                            li_val = val["Bag"]["li"]
-                            if li_val and isinstance(li_val, list) and len(li_val) > 0:
-                                xmp_data["tags"] = ", ".join(str(tag) for tag in li_val)
+                        tags = self._extract_xmp_subject_tags(val)
+                        if tags:
+                            xmp_data["tags"] = tags
         except Exception as e:
             logger.debug(f"Error reading XMP data for {filepath}: {e}")
 

--- a/test/core/metadata/test_image_strategy.py
+++ b/test/core/metadata/test_image_strategy.py
@@ -5,12 +5,13 @@ This module verifies the extraction of metadata from image files, including
 dimensions, orientation, and EXIF data.
 """
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from picframe.core.metadata.image_strategy import ImageMetadataStrategy
-from picframe.core.models.media import MediaType
+from picframe.core.models.media import MediaItem, MediaType
 
 
 @pytest.fixture
@@ -155,7 +156,7 @@ def _extract_with_dimensions(
     strategy: ImageMetadataStrategy,
     dimensions: tuple[int, int],
     orientation: int,
-):
+) -> MediaItem | None:
     with (
         patch("os.path.isfile", return_value=True),
         patch("os.stat") as mock_stat,
@@ -214,3 +215,79 @@ def test_extract_exception_handling(
     assert result is not None
     assert result.file_size == 1024
     assert result.last_modified == 1678886400.0
+
+
+# ---------------------------------------------------------------------------
+# XMP subject parsing — Bag/li vs Seq/li fallback (#725)
+# ---------------------------------------------------------------------------
+
+
+def _make_xmp_with_subject(subject_val: Any) -> dict[str, Any]:
+    """Build a minimal XMP dict containing only the subject key."""
+    return {"xmp": {"subject": subject_val}}
+
+
+def test_get_xmp_data_subject_bag_li(strategy: ImageMetadataStrategy) -> None:
+    """Bag/li list is the common case and must keep working (regression)."""
+    xmp = _make_xmp_with_subject({"Bag": {"li": ["vacation", "sunset"]}})
+    with patch("PIL.Image.open") as mock_open:
+        mock_img = MagicMock()
+        mock_img.getxmp.return_value = xmp
+        mock_open.return_value.__enter__.return_value = mock_img
+        result = strategy._get_xmp_data("/fake/path.jpg")
+    assert result.get("tags") == "vacation, sunset"
+
+
+def test_get_xmp_data_subject_seq_li(strategy: ImageMetadataStrategy) -> None:
+    """Seq/li list is written by ACDSee Photo Studio on Mac and must be parsed (#725)."""
+    xmp = _make_xmp_with_subject({"Seq": {"li": ["mountains", "hiking"]}})
+    with patch("PIL.Image.open") as mock_open:
+        mock_img = MagicMock()
+        mock_img.getxmp.return_value = xmp
+        mock_open.return_value.__enter__.return_value = mock_img
+        result = strategy._get_xmp_data("/fake/path.jpg")
+    assert result.get("tags") == "mountains, hiking"
+
+
+def test_get_xmp_data_subject_bag_li_single_string(strategy: ImageMetadataStrategy) -> None:
+    """Bag/li with a single-string li value should return that string (#725)."""
+    xmp = _make_xmp_with_subject({"Bag": {"li": "solo-keyword"}})
+    with patch("PIL.Image.open") as mock_open:
+        mock_img = MagicMock()
+        mock_img.getxmp.return_value = xmp
+        mock_open.return_value.__enter__.return_value = mock_img
+        result = strategy._get_xmp_data("/fake/path.jpg")
+    assert result.get("tags") == "solo-keyword"
+
+
+def test_get_xmp_data_subject_seq_li_single_string(strategy: ImageMetadataStrategy) -> None:
+    """Seq/li with a single-string li value should return that string (ACDSee, #725)."""
+    xmp = _make_xmp_with_subject({"Seq": {"li": "acdsee-keyword"}})
+    with patch("PIL.Image.open") as mock_open:
+        mock_img = MagicMock()
+        mock_img.getxmp.return_value = xmp
+        mock_open.return_value.__enter__.return_value = mock_img
+        result = strategy._get_xmp_data("/fake/path.jpg")
+    assert result.get("tags") == "acdsee-keyword"
+
+
+def test_get_xmp_data_subject_missing(strategy: ImageMetadataStrategy) -> None:
+    """When neither Bag nor Seq is present, no tags key should be set."""
+    xmp = _make_xmp_with_subject({"Other": {"li": ["nope"]}})
+    with patch("PIL.Image.open") as mock_open:
+        mock_img = MagicMock()
+        mock_img.getxmp.return_value = xmp
+        mock_open.return_value.__enter__.return_value = mock_img
+        result = strategy._get_xmp_data("/fake/path.jpg")
+    assert "tags" not in result
+
+
+def test_get_xmp_data_subject_prefers_bag_over_seq(strategy: ImageMetadataStrategy) -> None:
+    """Bag/li is preferred when both Bag and Seq are present."""
+    xmp = _make_xmp_with_subject({"Bag": {"li": ["preferred"]}, "Seq": {"li": ["fallback"]}})
+    with patch("PIL.Image.open") as mock_open:
+        mock_img = MagicMock()
+        mock_img.getxmp.return_value = xmp
+        mock_open.return_value.__enter__.return_value = mock_img
+        result = strategy._get_xmp_data("/fake/path.jpg")
+    assert result.get("tags") == "preferred"


### PR DESCRIPTION
## Summary

Adds a `Seq/li` fallback to XMP subject parsing in `ImageMetadataStrategy._get_xmp_data()` so ACDSee Photo Studio on Mac (which writes keywords under `Seq/li` instead of the common `Bag/li`) no longer silently misses tags from HEIC files.

Closes #725

## Context

Legacy PR #548 targeted removed legacy code (`src/picframe/get_image_meta.py`). Two of its three insights are already handled in next-gen:
- ✅ Description robustness (`Alt/li/text` checks) — already done
- ✅ Defensive `isinstance` checks / warning suppression — already done
- ❌ **Subject fallback to `Seq/li`** — the gap fixed here

## Changes

- **`src/picframe/core/metadata/image_strategy.py`**
  - New static helper `_extract_xmp_subject_tags(val)`:
    - Tries `Bag/li` first (existing behavior)
    - Falls back to `Seq/li` when `Bag/li` is missing (ACDSee on Mac)
    - Handles `li` as a list → `, `.join (existing)
    - Handles `li` as a single string → use the string directly (new — ACDSee may write a single keyword as a string)
  - `_get_xmp_data()` subject block now calls the helper.

- **`test/core/metadata/test_image_strategy.py`**
  - `test_get_xmp_data_subject_bag_li` — Bag/li list (regression)
  - `test_get_xmp_data_subject_seq_li` — Seq/li list (new fix)
  - `test_get_xmp_data_subject_bag_li_single_string` — Bag/li single string (defensive)
  - `test_get_xmp_data_subject_seq_li_single_string` — Seq/li single string (ACDSee)
  - `test_get_xmp_data_subject_missing` — neither Bag nor Seq → no tags key
  - `test_get_xmp_data_subject_prefers_bag_over_seq` — Bag/li preferred when both present

- **Memory Bank** (`activeContext.md`, `progress.md`, `decisionLog.md`) — concise #725 entries.

## Verification

- `pytest test/core/metadata/test_image_strategy.py -v` → 14 passed
- `mypy` → Success: no issues found in 2 source files
- `ruff check` + `ruff format --check` → clean

## Risks

Low. Change is isolated to XMP subject parsing with defensive `isinstance` checks. No DB schema, API, or architecture boundary impact. Existing `Bag/li` behavior preserved as the first-choice path.

## Summary by Sourcery

Improve XMP subject parsing and Wayland video worker robustness, adding environment safeguards, better diagnostics, and targeted tests.

New Features:
- Support extracting XMP subject keywords from both Bag/li and Seq/li containers, including single-string values, so ACDSee Photo Studio on Mac keywords are correctly imported.
- Auto-detect a single Wayland display socket from XDG_RUNTIME_DIR when WAYLAND_DISPLAY is unset, and enforce GDK_BACKEND=wayland in the GStreamer worker environment to avoid X11/Xwayland fallback crashes.
- Log display-related environment variables in the GStreamer worker at startup to leave a diagnostic trail for silent GTK4/Wayland initialization failures.

Bug Fixes:
- Prevent XMP tags written under Seq/li from being silently ignored, ensuring HEIC keywords from ACDSee Photo Studio on Mac are surfaced as image tags.
- Reduce green-screen and segfault crashes on Raspberry Pi 5 under labwc by forcing GTK4 to use native Wayland instead of X11/Xwayland and by validating the Wayland display configuration.

Enhancements:
- Add a shared helper for XMP subject tag extraction to centralize Bag/Seq handling and keep the parsing logic testable.
- Include explicit hints about GTK4/Wayland display initialization failures in worker crash error messages when the exit code is negative.
- Document the GTK-backed Wayland video handoff environment behavior and worker safeguards in the architecture overview.
- Update Memory Bank context, progress, and decision logs to capture the Seq/li fallback decision and Wayland environment changes.

Tests:
- Add unit tests covering XMP subject extraction for Bag/li and Seq/li with list and single-string values, missing-subject cases, and Bag-preferred-over-Seq behavior.
- Add tests verifying the worker environment enforces GDK_BACKEND=wayland, warns when WAYLAND_DISPLAY is missing or ambiguous, auto-detects a single Wayland socket, and logs display-related hints on worker crashes.