### PR TITLE
feat(hal): wake display on mouse/keyboard input via evdev (#762)

### DIFF
--- a/docs/dev/architecture/overlay.md
+++ b/docs/dev/architecture/overlay.md
@@ -477,6 +477,49 @@ restart guard, internal and external cycles heal identically. This mirrors
 the worker-isolation non-negotiable: WebKitGTK can crash or leak, so respawn
 rather than fix the live process.
 
+### Wake-on-input while the output is off (#762)
+
+While the Wayland output is destroyed by `wlr-randr --off` (or a compositor
+DPMS blank), the overlay's JS listeners cannot fire — the layer-shell surface
+is gone — so moving the mouse or pressing a key does nothing until picframe
+re-creates the output itself. The **backend wake-on-input path** closes that
+gap: a new `IWakeInputListener` port reads raw `/dev/input/event*` devices
+*independent of any Wayland surface*, so it works in the off state.
+
+`EvdevWakeAdapter` (`infrastructure/os/evdev_wake_adapter.py`) implements the
+port using the `evdev` library (a Linux-only dependency, lazy-imported). It
+listens **passively** (no `grab()`), so the compositor keeps receiving events
+for normal UI while the display is on. It filters to pointer + keyboard
+devices — touch devices are excluded by design (the surface is destroyed
+while off, and touch-on-a-dark-screen is not a wake gesture) — and emits
+`"mouse"` on relative pointer motion and `"keyboard"` on a key
+press/repeat (releases are ignored).
+
+`WakeOnInputService` (`core/services/wake_on_input.py`) turns those raw
+events into `Command.DISPLAY_ON` on the event bus. It is gated by:
+
+- **`overlay.enabled_input_types`** — only `mouse`/`keyboard` are
+  wake-capable; `touch` never wakes (the service enforces this even if a
+  future adapter emitted it). Disabling both classes from the web UI
+  disables wake-on-input live (the service reloads on a `CONFIG_CHANGED`
+  whose `updated_sections` contains `"overlay"`).
+- **The current display state** — it is idempotent: `IDisplayPower.is_on()`
+  is checked first, so an already-on display is never re-woken.
+- **A 1 s cooldown debounce** — a burst of mouse moves while the display is
+  still transitioning on publishes at most one `DISPLAY_ON`.
+
+It deliberately publishes **only `DISPLAY_ON`**; the `PLAY` side-effect is
+owned by `DisplayPowerManager`, keeping the single-owner responsibility
+intact.
+
+The HAL factory injects `EvdevWakeAdapter` on Linux when `evdev` is
+importable and at least one `/dev/input/event*` device is readable;
+otherwise it falls back to `MockWakeInputListener` (dev/CI/headless). The
+picframe user must be in the **`input`** group for `/dev/input/event*`
+access — the install script (`docs/user/install_picframe.sh`) already adds
+this. The adapter degrades gracefully if a device is unreadable: it logs a
+warning and skips that device rather than crashing.
+
 ### Why a worker self-report was attempted and reverted
 
 An earlier Phase-2 design tried to make output loss event-driven: the worker

--- a/docs/user/install_picframe.sh
+++ b/docs/user/install_picframe.sh
@@ -534,7 +534,7 @@ echo "[4/7] Configuring user groups for hardware access..."
 usermod -aG i2c "$ACTUAL_USER"
 usermod -aG video "$ACTUAL_USER"
 usermod -aG render "$ACTUAL_USER" || true # Add to render group for DRM/KMS access if it exists
-usermod -aG input "$ACTUAL_USER" || true # Hardware/event access on some Lite installs
+usermod -aG input "$ACTUAL_USER" || true # /dev/input/event* access: evdev wake-on-input (#762) + some Lite installs
 usermod -aG seat "$ACTUAL_USER" || true # seatd access for kiosk Wayland sessions if present
 
 # 5. Configure sudoers rules for reboot/shutdown and Picframe service restart

--- a/docs/user/overlay.md
+++ b/docs/user/overlay.md
@@ -56,6 +56,15 @@ full opacity; after the idle interval it fades to transparent again. The
 overlay is **always on top and always the input surface** — "transparent" does
 not mean "off", so a tap always brings it back.
 
+> **Waking a powered-off display:** while the screen itself is turned off
+> (display power-off / monitor DPMS), the overlay surface is destroyed, so the
+> in-page listeners above cannot fire. Picframe also runs a backend
+> `evdev`-based input listener that reads `/dev/input/event*` directly and
+> turns the display back on when you move the mouse or press a key — as long
+> as `mouse` and/or `keyboard` are in `overlay.enabled_input_types` (`touch`
+> never wakes the display). This needs the picframe user in the `input` group,
+> which the install script adds automatically.
+
 ### Navigation
 
 The whole overlay area captures input and routes it as playback commands:

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -244,6 +244,17 @@ ticket is in `decisionLog.md` and the linked GitHub Issues.
   reject `WAKE`/`SLEEP` → use `DISPLAY_ON`/`DISPLAY_OFF`, #705); PIR no-motion
   timers in `HardwareInputService` (#635, #703); saving is a replacement not
   merge (#702); display-power commands idempotent (#704).
+- **Wake-on-input (#762):** a purpose-built `IWakeInputListener` port + backend
+  `EvdevWakeAdapter` (lazy `evdev`, passive no-grab `/dev/input/event*` read,
+  mouse+keyboard only, touch excluded) feeds `WakeOnInputService`, which publishes
+  only `Command.DISPLAY_ON` (never `PLAY` — that side-effect stays owned by
+  `DisplayPowerManager`) so the display wakes from the `wlr-randr --off`-destroyed
+  state where the overlay's JS listeners cannot fire. Gated by the existing
+  `overlay.enabled_input_types` (no new config key), idempotent via
+  `IDisplayPower.is_on()`, 1 s cooldown debounce, live-reloads on overlay config
+  change. `evdev>=1.6.0` is a Linux-only marker dependency (`sys_platform ==
+  'linux'`); the installer already adds the `input` group it needs. Additive to,
+  and distinct from, the GPIO/PIR `HardwareInputService`.
 - **Video handoff:** require `gtk4paintablesink`; 99% opacity redraw handshake at
   EOS; no legacy sink fallbacks; final-frame extraction at indexing time, not
   EOS runtime; geometry from `content_rect` sidecar (#691/#698).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "ninepatch>=0.2.0",
     "pi_heif>=0.8.0",
     "gpiozero>=2.0.0",
+    "evdev>=1.6.0; sys_platform == 'linux'",
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
     "websockets>=11.0.0",

--- a/src/picframe/core/ports/__init__.py
+++ b/src/picframe/core/ports/__init__.py
@@ -2,7 +2,13 @@
 Hardware Abstraction Layer (HAL) Ports package.
 """
 
-from .hal import IDisplayPower, IHardwareInput, ISystemManager
+from .hal import IDisplayPower, IHardwareInput, ISystemManager, IWakeInputListener
 from .overlay import IOverlayController
 
-__all__ = ["IDisplayPower", "IHardwareInput", "ISystemManager", "IOverlayController"]
+__all__ = [
+    "IDisplayPower",
+    "IHardwareInput",
+    "ISystemManager",
+    "IWakeInputListener",
+    "IOverlayController",
+]

--- a/src/picframe/core/ports/hal.py
+++ b/src/picframe/core/ports/hal.py
@@ -78,6 +78,40 @@ class IHardwareInput(Protocol):
         ...
 
 
+class IWakeInputListener(Protocol):
+    """
+    Interface for a backend hardware-input listener that wakes the display.
+
+    Unlike ``IHardwareInput`` (which maps user-configured GPIO/PIR inputs to
+    commands), this listener is purpose-built to wake the display from the
+    "off" state on raw mouse-move / keypress events. It reads input devices
+    *independent of any Wayland surface* so it works while the configured
+    output is destroyed by ``wlr-randr --off`` (#762).
+
+    The registered callback receives an input-class string ("mouse" or
+    "keyboard"); the owning service applies gating and debounce and publishes
+    the actual ``CommandEvent``.
+    """
+
+    def register_callback(self, callback: Callable[[str], None]) -> None:
+        """
+        Register a callback invoked when a wake-capable input event occurs.
+
+        Args:
+            callback: A function taking an input-class string
+                      ("mouse" or "keyboard").
+        """
+        ...
+
+    def start(self) -> None:
+        """Start listening for wake-capable input events."""
+        ...
+
+    def stop(self) -> None:
+        """Stop listening and release input-device resources."""
+        ...
+
+
 class ISystemManager(Protocol):
     """
     Interface for executing system-level commands.

--- a/src/picframe/core/services/wake_on_input.py
+++ b/src/picframe/core/services/wake_on_input.py
@@ -1,0 +1,127 @@
+"""
+Wake-on-Input Service (#762).
+
+Turns raw mouse/keyboard wake events from a backend input-device listener
+(:class:`~picframe.core.ports.IWakeInputListener`) into ``Command.DISPLAY_ON``
+events on the event bus. The listener reads input devices *independent of any
+Wayland surface*, so it works while the configured output is destroyed by
+``wlr-randr --off`` (the overlay's JS listeners cannot fire in that state).
+
+The service is gated by the overlay's ``enabled_input_types`` list (mouse and
+keyboard are wake-capable; touch is never a wake class) and by the current
+display-power state (idempotent — it never wakes an already-on display). It
+applies a short cooldown debounce to avoid publishing a storm of wake events
+while the display is still transitioning on. It deliberately publishes only
+``DISPLAY_ON``; the ``PLAY`` side-effect is owned by ``DisplayPowerManager``.
+"""
+
+import logging
+import threading
+import time
+from typing import Any
+
+from picframe.core.events.dto import Command, CommandEvent, State, StateEvent
+from picframe.core.events.interfaces import IEventPublisher, IEventSubscriber
+from picframe.core.ports import IDisplayPower, IWakeInputListener
+from picframe.core.repositories.interfaces import IConfigRepository
+
+logger = logging.getLogger(__name__)
+
+# Input classes that are eligible to wake the display. Touch is excluded by
+# design: the overlay surface is destroyed while the output is off, so touch
+# listeners cannot fire anyway, and touch-on-a-dark-screen is not a wake gesture.
+WAKE_INPUT_CLASSES: frozenset[str] = frozenset({"mouse", "keyboard"})
+
+# Default ``overlay.enabled_input_types`` value used when the key is absent.
+_DEFAULT_ENABLED_INPUT_TYPES: list[str] = ["touch", "mouse", "keyboard"]
+
+# Minimum time between published wake events while the display is still off.
+# ``DisplayPowerManager`` already idempotently ignores duplicate ``DISPLAY_ON``
+# commands once ``is_on()`` returns True; this just avoids a burst of redundant
+# publishes during the brief turn-on transition.
+_WAKE_COOLDOWN_SECONDS: float = 1.0
+
+
+class WakeOnInputService:
+    """
+    Service that wakes the display on raw mouse-move / keypress events.
+
+    Subscribes to ``StateEvent`` (CONFIG_CHANGED) so it reloads the
+    ``overlay.enabled_input_types`` list live when the user changes it from
+    the web UI.
+    """
+
+    def __init__(
+        self,
+        event_publisher: IEventPublisher,
+        wake_adapter: IWakeInputListener,
+        display_power_adapter: IDisplayPower,
+        config_repository: IConfigRepository | None = None,
+        event_subscriber: IEventSubscriber | None = None,
+    ) -> None:
+        self._event_publisher = event_publisher
+        self._wake_adapter = wake_adapter
+        self._display_power = display_power_adapter
+        self._config_repository = config_repository
+        self._event_subscriber = event_subscriber
+        self._enabled_input_types: set[str] = set(_DEFAULT_ENABLED_INPUT_TYPES)
+        self._last_wake_time: float = 0.0
+        self._lock = threading.Lock()
+        self._is_subscribed = False
+
+        self._wake_adapter.register_callback(self._handle_wake_event)
+        if self._event_subscriber:
+            self._event_subscriber.subscribe(StateEvent, self._handle_state_event)
+            self._is_subscribed = True
+        logger.info("WakeOnInputService initialized.")
+
+    def _handle_wake_event(self, input_class: str) -> None:
+        """Callback from the wake adapter when a wake-capable input occurs."""
+        if input_class not in WAKE_INPUT_CLASSES:
+            return
+        if input_class not in self._enabled_input_types:
+            return
+        if self._display_power.is_on():
+            return
+        with self._lock:
+            now = time.monotonic()
+            if now - self._last_wake_time < _WAKE_COOLDOWN_SECONDS:
+                return
+            self._last_wake_time = now
+        logger.info("WakeOnInputService: waking display on %s input.", input_class)
+        self._event_publisher.publish(CommandEvent(command=Command.DISPLAY_ON))
+
+    def _handle_state_event(self, event: Any) -> None:
+        """Reload the enabled-input-types set on live overlay config changes."""
+        if not isinstance(event, StateEvent) or event.state != State.CONFIG_CHANGED:
+            return
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        updated_sections = payload.get("updated_sections", [])
+        if "overlay" not in updated_sections:
+            return
+        self._reload_enabled_input_types()
+
+    def _reload_enabled_input_types(self) -> None:
+        if self._config_repository is None:
+            return
+        raw = self._config_repository.get_app_config(
+            "overlay.enabled_input_types", _DEFAULT_ENABLED_INPUT_TYPES
+        )
+        if isinstance(raw, list):
+            self._enabled_input_types = {str(x) for x in raw}
+        else:
+            self._enabled_input_types = set(_DEFAULT_ENABLED_INPUT_TYPES)
+
+    def start(self) -> None:
+        """Reload config and start the underlying wake input adapter."""
+        logger.info("WakeOnInputService: starting.")
+        self._reload_enabled_input_types()
+        self._wake_adapter.start()
+
+    def stop(self) -> None:
+        """Stop the underlying adapter and unsubscribe from config events."""
+        logger.info("WakeOnInputService: stopping.")
+        self._wake_adapter.stop()
+        if self._event_subscriber and self._is_subscribed:
+            self._event_subscriber.unsubscribe(StateEvent, self._handle_state_event)
+            self._is_subscribed = False

--- a/src/picframe/infrastructure/os/evdev_wake_adapter.py
+++ b/src/picframe/infrastructure/os/evdev_wake_adapter.py
@@ -66,7 +66,14 @@ class EvdevWakeAdapter(IWakeInputListener):
             return False
         if not os.path.isdir(_INPUT_DEVICE_DIR):
             return False
-        for name in os.listdir(_INPUT_DEVICE_DIR):
+        try:
+            names = os.listdir(_INPUT_DEVICE_DIR)
+        except OSError:
+            # Directory vanished or unreadable between the isdir check and
+            # enumeration; treat as "no wake devices available" so the HAL
+            # factory falls back to the mock listener (#762).
+            return False
+        for name in names:
             if not name.startswith("event"):
                 continue
             path = os.path.join(_INPUT_DEVICE_DIR, name)
@@ -88,7 +95,17 @@ class EvdevWakeAdapter(IWakeInputListener):
             return
 
         self._stop_event.clear()
-        for name in os.listdir(_INPUT_DEVICE_DIR):
+        try:
+            names = os.listdir(_INPUT_DEVICE_DIR)
+        except OSError as exc:
+            logger.warning(
+                "EvdevWakeAdapter: Cannot enumerate %s (%s); wake-on-input inactive.",
+                _INPUT_DEVICE_DIR,
+                exc,
+            )
+            self._started = True
+            return
+        for name in names:
             if not name.startswith("event"):
                 continue
             path = os.path.join(_INPUT_DEVICE_DIR, name)

--- a/src/picframe/infrastructure/os/evdev_wake_adapter.py
+++ b/src/picframe/infrastructure/os/evdev_wake_adapter.py
@@ -1,0 +1,194 @@
+"""
+Evdev wake-input adapter (#762).
+
+Reads raw input devices under ``/dev/input/event*`` via the ``evdev`` library
+so the backend can wake the display while the configured Wayland output is
+destroyed by ``wlr-randr --off`` (the overlay's JS listeners cannot fire in
+that state because the layer-shell surface is gone).
+
+The adapter listens *passively* (it does not ``grab()`` devices), so the
+compositor keeps receiving events for normal UI while the display is on. It
+filters to pointer + keyboard devices (touch devices are excluded by design)
+and emits ``"mouse"`` on relative pointer motion and ``"keyboard"`` on key
+events.
+
+The ``evdev`` dependency is imported lazily so this module imports cleanly on
+non-Linux / CI hosts. :meth:`is_available` probes whether input devices exist
+and are readable; if not, the HAL factory falls back to the mock listener.
+"""
+
+import logging
+import os
+import threading
+from collections.abc import Callable
+
+from picframe.core.ports import IWakeInputListener
+
+logger = logging.getLogger(__name__)
+
+# evdev event/bit constants used for device classification. Defined here as
+# module-level ints so the adapter can be unit-tested without importing evdev
+# (the real values come from the kernel uapi headers and never change).
+_EV_REL = 0x02
+_EV_KEY = 0x01
+_REL_X = 0x00
+_REL_Y = 0x01
+_BTN_LEFT = 0x110
+_KEY_ESC = 0x01
+_BTN_TOUCH = 0x14A
+
+_INPUT_DEVICE_DIR = "/dev/input"
+
+
+class EvdevWakeAdapter(IWakeInputListener):
+    """
+    Backend wake-input listener backed by the ``evdev`` library.
+
+    Reads pointer and keyboard ``/dev/input/event*`` devices on daemon threads
+    and invokes the registered callback with ``"mouse"`` or ``"keyboard"``
+    when a wake-capable event occurs.
+    """
+
+    def __init__(self) -> None:
+        self._callback: Callable[[str], None] | None = None
+        self._threads: list[threading.Thread] = []
+        self._devices: list[object] = []
+        self._stop_event = threading.Event()
+        self._started = False
+        logger.info("EvdevWakeAdapter initialized.")
+
+    @staticmethod
+    def is_available() -> bool:
+        """Probe whether ``evdev`` is importable and input devices are readable."""
+        try:
+            import evdev  # noqa: F401  pylint: disable=import-outside-toplevel
+        except ImportError:
+            return False
+        if not os.path.isdir(_INPUT_DEVICE_DIR):
+            return False
+        for name in os.listdir(_INPUT_DEVICE_DIR):
+            if not name.startswith("event"):
+                continue
+            path = os.path.join(_INPUT_DEVICE_DIR, name)
+            if os.access(path, os.R_OK):
+                return True
+        return False
+
+    def register_callback(self, callback: Callable[[str], None]) -> None:
+        self._callback = callback
+        logger.info("EvdevWakeAdapter: Callback registered.")
+
+    def start(self) -> None:
+        if self._started:
+            return
+        try:
+            import evdev  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            logger.warning("EvdevWakeAdapter: 'evdev' not available; wake-on-input disabled.")
+            return
+
+        self._stop_event.clear()
+        for name in os.listdir(_INPUT_DEVICE_DIR):
+            if not name.startswith("event"):
+                continue
+            path = os.path.join(_INPUT_DEVICE_DIR, name)
+            try:
+                device = evdev.InputDevice(path)
+            except (OSError, PermissionError) as exc:
+                logger.warning(
+                    "EvdevWakeAdapter: Cannot open %s (%s); skipping. "
+                    "Is the picframe user in the 'input' group?",
+                    path,
+                    exc,
+                )
+                continue
+            if not self._is_wake_device(device):
+                logger.debug("EvdevWakeAdapter: Skipping non-wake device %s.", path)
+                continue
+            self._devices.append(device)
+            thread = threading.Thread(
+                target=self._read_loop,
+                args=(device,),
+                name=f"evdev-wake-{name}",
+                daemon=True,
+            )
+            self._threads.append(thread)
+            thread.start()
+            logger.info("EvdevWakeAdapter: Listening on %s (%s).", path, device.name)
+
+        if not self._threads:
+            logger.warning(
+                "EvdevWakeAdapter: No readable pointer/keyboard input devices found; "
+                "wake-on-input inactive."
+            )
+        self._started = True
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        for device in self._devices:
+            try:
+                device.close()  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001  pylint: disable=broad-except
+                pass
+        for thread in self._threads:
+            thread.join(timeout=2.0)
+        self._devices.clear()
+        self._threads.clear()
+        self._started = False
+        logger.info("EvdevWakeAdapter: Stopped.")
+
+    # -- internals ----------------------------------------------------------
+
+    @staticmethod
+    def _is_wake_device(device: object) -> bool:
+        """Return True for pointer (mouse) or keyboard devices; exclude touch."""
+        try:
+            caps = device.capabilities(absinfo=False)  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001  pylint: disable=broad-except
+            return False
+        ev_rel = _EV_REL in caps
+        ev_key = _EV_KEY in caps
+        if ev_rel and ev_key:
+            # Relative-pointer device with mouse buttons — a mouse.
+            return True
+        if ev_key and not ev_rel:
+            key_bits = caps.get(_EV_KEY, [])
+            # Keyboard: has standard keys but no touch button.
+            has_keys = any(_KEY_ESC <= b < _BTN_LEFT for b in key_bits)
+            has_touch = _BTN_TOUCH in key_bits
+            return has_keys and not has_touch
+        return False
+
+    def _read_loop(self, device: object) -> None:
+        while not self._stop_event.is_set():
+            try:
+                for event in device.read_loop():  # type: ignore[attr-defined]
+                    if self._stop_event.is_set():
+                        break
+                    input_class = self._classify(event)
+                    if input_class and self._callback:
+                        self._callback(input_class)
+            except OSError as exc:
+                if self._stop_event.is_set():
+                    break
+                logger.warning("EvdevWakeAdapter: read error on %s: %s", device, exc)
+                break
+            except Exception:  # noqa: BLE001  pylint: disable=broad-except
+                if self._stop_event.is_set():
+                    break
+                logger.exception("EvdevWakeAdapter: Unexpected error in read loop.")
+                break
+
+    @staticmethod
+    def _classify(event: object) -> str | None:
+        """Map a raw input event to a wake input-class, or None if not wake-worthy."""
+        etype = event.type  # type: ignore[attr-defined]
+        if etype == _EV_REL and event.code in (_REL_X, _REL_Y):  # type: ignore[attr-defined]
+            return "mouse"
+        if etype == _EV_KEY:
+            code = event.code  # type: ignore[attr-defined]
+            value = event.value  # type: ignore[attr-defined]
+            # value 1 = key press, 2 = key repeat; ignore releases (0).
+            if _KEY_ESC <= code < _BTN_LEFT and value != 0:
+                return "keyboard"
+        return None

--- a/src/picframe/infrastructure/os/hal_factory.py
+++ b/src/picframe/infrastructure/os/hal_factory.py
@@ -13,12 +13,13 @@ from dataclasses import dataclass
 from typing import Any
 
 from picframe.core.events.interfaces import IEventPublisher
-from picframe.core.ports import IDisplayPower, IHardwareInput, ISystemManager
+from picframe.core.ports import IDisplayPower, IHardwareInput, ISystemManager, IWakeInputListener
 from picframe.infrastructure.os.linux_system_manager import LinuxSystemManager
 from picframe.infrastructure.os.mock_adapters import (
     MockDisplayPower,
     MockHardwareInput,
     MockSystemManager,
+    MockWakeInputListener,
 )
 from picframe.infrastructure.os.wayland_power import WaylandDisplayPower
 
@@ -34,6 +35,7 @@ class HALAdapters:
     display_power: IDisplayPower
     hardware_input: IHardwareInput
     system_manager: ISystemManager
+    wake_input: IWakeInputListener | None = None
 
 
 class HALFactory:
@@ -61,6 +63,23 @@ class HALFactory:
     @staticmethod
     def _has_wlr_randr() -> bool:
         return shutil.which("wlr-randr") is not None
+
+    @staticmethod
+    def _create_wake_input_listener() -> IWakeInputListener:
+        """Pick a wake-input listener: evdev on real Linux, mock otherwise (#762)."""
+        if sys.platform.startswith("linux"):
+            from picframe.infrastructure.os.evdev_wake_adapter import EvdevWakeAdapter
+
+            if EvdevWakeAdapter.is_available():
+                logger.info("HALFactory: evdev input devices found. Injecting EvdevWakeAdapter.")
+                return EvdevWakeAdapter()
+            logger.info(
+                "HALFactory: No readable /dev/input devices (or 'evdev' missing). "
+                "Injecting MockWakeInputListener."
+            )
+        else:
+            logger.info("HALFactory: Non-Linux host. Injecting MockWakeInputListener.")
+        return MockWakeInputListener()
 
     @staticmethod
     def create_adapters(
@@ -92,6 +111,7 @@ class HALFactory:
                 display_power=MockDisplayPower(),
                 hardware_input=MockHardwareInput(),
                 system_manager=MockSystemManager(),
+                wake_input=MockWakeInputListener(),
             )
 
         # Linux environment detection
@@ -117,6 +137,7 @@ class HALFactory:
                 display_power=MockDisplayPower(),
                 hardware_input=MockHardwareInput(),
                 system_manager=LinuxSystemManager(),
+                wake_input=MockWakeInputListener(),
             )
 
         # Determine Display Power Adapter
@@ -151,4 +172,5 @@ class HALFactory:
             display_power=display_power,
             hardware_input=hardware_input,
             system_manager=LinuxSystemManager(),
+            wake_input=HALFactory._create_wake_input_listener(),
         )

--- a/src/picframe/infrastructure/os/mock_adapters.py
+++ b/src/picframe/infrastructure/os/mock_adapters.py
@@ -10,7 +10,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from picframe.core.ports import IDisplayPower, IHardwareInput, ISystemManager
+from picframe.core.ports import IDisplayPower, IHardwareInput, ISystemManager, IWakeInputListener
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +102,45 @@ class MockHardwareInput(IHardwareInput):
             logger.warning("MockHardwareInput: Cannot simulate event, monitoring is stopped.")
         else:
             logger.warning("MockHardwareInput: Cannot simulate event, no callback registered.")
+
+
+class MockWakeInputListener(IWakeInputListener):
+    """Mock implementation of IWakeInputListener for dev/test environments."""
+
+    def __init__(self) -> None:
+        self._is_running = False
+        self._callback: Callable[[str], None] | None = None
+        logger.info("MockWakeInputListener initialized.")
+
+    def register_callback(self, callback: Callable[[str], None]) -> None:
+        """Register a callback for simulated wake events."""
+        self._callback = callback
+        logger.info("MockWakeInputListener: Callback registered.")
+
+    def start(self) -> None:
+        """Simulate starting wake-input monitoring."""
+        self._is_running = True
+        logger.info("MockWakeInputListener: Monitoring started.")
+
+    def stop(self) -> None:
+        """Simulate stopping wake-input monitoring."""
+        self._is_running = False
+        logger.info("MockWakeInputListener: Monitoring stopped.")
+
+    def simulate_event(self, input_class: str) -> None:
+        """
+        Simulate a wake-capable input event.
+
+        Args:
+            input_class: The input class ("mouse" or "keyboard").
+        """
+        if self._is_running and self._callback:
+            logger.info("MockWakeInputListener: Simulating %s wake event.", input_class)
+            self._callback(input_class)
+        elif not self._is_running:
+            logger.warning("MockWakeInputListener: Cannot simulate, monitoring stopped.")
+        else:
+            logger.warning("MockWakeInputListener: Cannot simulate, no callback registered.")
 
 
 class MockSystemManager(ISystemManager):

--- a/src/picframe/main.py
+++ b/src/picframe/main.py
@@ -34,6 +34,7 @@ from picframe.core.services.resource_paths import (
     repair_legacy_resource_defaults,
 )
 from picframe.core.services.state_tracker import StateTrackerService
+from picframe.core.services.wake_on_input import WakeOnInputService
 from picframe.infrastructure.filesystem.media_monitor import WatchdogMediaMonitor
 from picframe.infrastructure.mqtt import HomeAssistantMqttAdapter
 from picframe.infrastructure.os.hal_factory import HALFactory
@@ -103,6 +104,20 @@ def run_picframe(
         config_repository=_config_repo,
         event_subscriber=event_bus,
     )
+
+    # Wake-on-input service (#762): wakes the display on raw mouse-move /
+    # keypress events while the Wayland output is destroyed by ``wlr-randr
+    # --off``. Only constructed when the HAL factory provided a wake listener;
+    # the mock listener is harmless on dev/non-Linux hosts.
+    wake_on_input_service: WakeOnInputService | None = None
+    if hal_adapters.wake_input is not None:
+        wake_on_input_service = WakeOnInputService(
+            event_publisher=event_bus,
+            wake_adapter=hal_adapters.wake_input,
+            display_power_adapter=hal_adapters.display_power,
+            config_repository=_config_repo,
+            event_subscriber=event_bus,
+        )
 
     # Initialize ImageProcessingService
     cache_dir = os.path.join(data_dir, "cache")
@@ -278,6 +293,8 @@ def run_picframe(
         web_server.stop()
         mqtt_adapter.stop()
         hardware_input_service.stop()
+        if wake_on_input_service is not None:
+            wake_on_input_service.stop()
         logging_service.stop()
         engine.stop()
         media_indexer_service.stop()
@@ -290,6 +307,7 @@ def run_picframe(
         _ = display_power_manager
         _ = system_manager
         _ = hardware_input_service
+        _ = wake_on_input_service
         _ = config_service
         _ = state_tracker
         _ = logging_service
@@ -315,6 +333,10 @@ def run_picframe(
     logger.info("Starting Hardware Input Service...")
     hardware_input_service.start()
 
+    if wake_on_input_service is not None:
+        logger.info("Starting Wake-on-Input Service...")
+        wake_on_input_service.start()
+
     logger.info("Starting Playback Engine...")
     # engine.start() blocks until stopped
     try:
@@ -334,6 +356,8 @@ def run_picframe(
         image_processing_service.shutdown()
         mqtt_adapter.stop()
         hardware_input_service.stop()
+        if wake_on_input_service is not None:
+            wake_on_input_service.stop()
         web_server.stop()
         engine.stop()
         overlay_controller.stop()

--- a/test/core/services/test_wake_on_input.py
+++ b/test/core/services/test_wake_on_input.py
@@ -1,0 +1,182 @@
+"""
+Tests for the WakeOnInputService.
+
+The service turns raw mouse/keyboard wake events (from a backend input-device
+listener that works while the Wayland output is destroyed by ``wlr-randr
+--off``) into ``Command.DISPLAY_ON`` events, gated by the overlay's
+``enabled_input_types`` list and the current display-power state (#762).
+"""
+
+from unittest.mock import MagicMock
+
+from picframe.core.events.dto import Command, CommandEvent, State, StateEvent
+from picframe.core.services.wake_on_input import WakeOnInputService
+
+
+def _make_service(
+    display_on: bool = False,
+    enabled_input_types: list[str] | None = None,
+) -> tuple[WakeOnInputService, MagicMock, MagicMock, MagicMock, MagicMock, MagicMock]:
+    """Build a service wired to mocks; return (service, bus, adapter, dp, repo, sub)."""
+    if enabled_input_types is None:
+        enabled_input_types = ["touch", "mouse", "keyboard"]
+    mock_publisher = MagicMock()
+    mock_wake_adapter = MagicMock()
+    mock_display_power = MagicMock()
+    mock_display_power.is_on.return_value = display_on
+    mock_config_repo = MagicMock()
+    mock_config_repo.get_app_config.return_value = enabled_input_types
+    mock_subscriber = MagicMock()
+
+    service = WakeOnInputService(
+        event_publisher=mock_publisher,
+        wake_adapter=mock_wake_adapter,
+        display_power_adapter=mock_display_power,
+        config_repository=mock_config_repo,
+        event_subscriber=mock_subscriber,
+    )
+    return (
+        service,
+        mock_publisher,
+        mock_wake_adapter,
+        mock_display_power,
+        mock_config_repo,
+        mock_subscriber,
+    )
+
+
+def test_wake_on_input_registers_callback_and_subscribes() -> None:
+    service, _, mock_wake_adapter, _, _, mock_subscriber = _make_service()
+
+    mock_wake_adapter.register_callback.assert_called_once_with(service._handle_wake_event)
+    mock_subscriber.subscribe.assert_any_call(StateEvent, service._handle_state_event)
+
+
+def test_wake_on_input_publishes_display_on_when_off_and_mouse_enabled() -> None:
+    service, mock_publisher, _, _, _, _ = _make_service(display_on=False)
+    service.start()
+
+    service._handle_wake_event("mouse")
+
+    mock_publisher.publish.assert_called_once_with(CommandEvent(command=Command.DISPLAY_ON))
+
+
+def test_wake_on_input_publishes_display_on_when_off_and_keyboard_enabled() -> None:
+    service, mock_publisher, _, _, _, _ = _make_service(display_on=False)
+    service.start()
+
+    service._handle_wake_event("keyboard")
+
+    mock_publisher.publish.assert_called_once_with(CommandEvent(command=Command.DISPLAY_ON))
+
+
+def test_wake_on_input_noop_when_display_already_on() -> None:
+    service, mock_publisher, _, mock_dp, _, _ = _make_service(display_on=True)
+    service.start()
+
+    service._handle_wake_event("mouse")
+
+    mock_dp.is_on.assert_called()
+    mock_publisher.publish.assert_not_called()
+
+
+def test_wake_on_input_ignores_disabled_input_class() -> None:
+    # Kiosk: only touch enabled — mouse/keyboard must not wake.
+    service, mock_publisher, _, mock_dp, _, _ = _make_service(
+        display_on=False, enabled_input_types=["touch"]
+    )
+    service.start()
+
+    service._handle_wake_event("mouse")
+    service._handle_wake_event("keyboard")
+
+    mock_dp.is_on.assert_not_called()
+    mock_publisher.publish.assert_not_called()
+
+
+def test_wake_on_input_touch_never_wakes() -> None:
+    """Touch devices are excluded by design (surface destroyed while off)."""
+    service, mock_publisher, _, mock_dp, _, _ = _make_service(display_on=False)
+    service.start()
+
+    service._handle_wake_event("touch")
+
+    mock_dp.is_on.assert_not_called()
+    mock_publisher.publish.assert_not_called()
+
+
+def test_wake_on_input_debounces_rapid_mouse_events() -> None:
+    """Rapid mouse moves publish at most one wake per cooldown window."""
+    service, mock_publisher, _, _, _, _ = _make_service(display_on=False)
+    service.start()
+
+    service._handle_wake_event("mouse")
+    service._handle_wake_event("mouse")
+    service._handle_wake_event("mouse")
+
+    mock_publisher.publish.assert_called_once_with(CommandEvent(command=Command.DISPLAY_ON))
+
+
+def test_wake_on_input_never_publishes_play() -> None:
+    """DisplayPowerManager owns the PLAY side-effect; the wake service only wakes."""
+    service, mock_publisher, _, _, _, _ = _make_service(display_on=False)
+    service.start()
+
+    service._handle_wake_event("keyboard")
+
+    for call in mock_publisher.publish.call_args_list:
+        published = call.args[0]
+        assert isinstance(published, CommandEvent)
+        assert published.command != Command.PLAY
+
+
+def test_wake_on_input_reloads_enabled_types_on_overlay_config_change() -> None:
+    service, _, _, _, mock_repo, _ = _make_service(
+        enabled_input_types=["touch", "mouse", "keyboard"]
+    )
+    service.start()
+    initial_calls = mock_repo.get_app_config.call_count
+
+    # Change config to kiosk (touch only).
+    mock_repo.get_app_config.return_value = ["touch"]
+    service._handle_state_event(
+        StateEvent(state=State.CONFIG_CHANGED, payload={"updated_sections": ["overlay"]})
+    )
+    assert mock_repo.get_app_config.call_count == initial_calls + 1
+
+    # A subsequent mouse event must be ignored now.
+    mock_publisher = MagicMock()
+    service._event_publisher = mock_publisher  # type: ignore[attr-defined]
+    service._handle_wake_event("mouse")
+    mock_publisher.publish.assert_not_called()
+
+
+def test_wake_on_input_ignores_config_change_for_other_sections() -> None:
+    service, _, _, _, mock_repo, _ = _make_service(
+        enabled_input_types=["touch", "mouse", "keyboard"]
+    )
+    service.start()
+    initial_calls = mock_repo.get_app_config.call_count
+
+    service._handle_state_event(
+        StateEvent(state=State.CONFIG_CHANGED, payload={"updated_sections": ["viewer"]})
+    )
+
+    assert mock_repo.get_app_config.call_count == initial_calls
+
+
+def test_wake_on_input_start_delegates_to_adapter_and_stops_cleanly() -> None:
+    service, _, mock_wake_adapter, _, _, mock_subscriber = _make_service()
+    service.start()
+    mock_wake_adapter.start.assert_called_once()
+
+    service.stop()
+    mock_wake_adapter.stop.assert_called_once()
+    mock_subscriber.unsubscribe.assert_any_call(StateEvent, service._handle_state_event)
+
+
+def test_wake_on_input_ignores_non_state_events() -> None:
+    service, _, _, _, mock_repo, _ = _make_service()
+    service._handle_state_event("not a state event")
+    # No reload should occur beyond construction.
+    service.stop()

--- a/test/infrastructure/os/test_evdev_wake_adapter.py
+++ b/test/infrastructure/os/test_evdev_wake_adapter.py
@@ -125,6 +125,22 @@ def test_is_available_false_when_evdev_missing() -> None:
         assert EvdevWakeAdapter.is_available() is False
 
 
+def test_is_available_false_when_listdir_raises() -> None:
+    # /dev/input exists but enumeration fails (vanished / transient error):
+    # must degrade to "not available" rather than raising (#762).
+    err = OSError("boom")
+
+    def _listdir(_path: str) -> list[str]:
+        raise err
+
+    with (
+        patch.dict("sys.modules", {"evdev": MagicMock()}),
+        patch("os.path.isdir", return_value=True),
+        patch("os.listdir", side_effect=_listdir),
+    ):
+        assert EvdevWakeAdapter.is_available() is False
+
+
 def test_start_open_and_listen_on_wake_device() -> None:
     adapter = EvdevWakeAdapter()
     fake_device = MagicMock()
@@ -196,3 +212,23 @@ def test_start_noop_without_evdev() -> None:
         adapter.start()
     assert adapter._threads == []
     assert adapter._started is False
+
+
+def test_start_inactive_when_listdir_raises() -> None:
+    # /dev/input enumeration fails at start(): must log + go inactive
+    # rather than propagating out of service startup (#762).
+    adapter = EvdevWakeAdapter()
+    err = OSError("boom")
+
+    def _listdir(_path: str) -> list[str]:
+        raise err
+
+    with (
+        patch.dict("sys.modules", {"evdev": MagicMock()}),
+        patch("os.listdir", side_effect=_listdir),
+    ):
+        adapter.start()
+
+    assert adapter._threads == []
+    assert adapter._started is True
+    adapter.stop()

--- a/test/infrastructure/os/test_evdev_wake_adapter.py
+++ b/test/infrastructure/os/test_evdev_wake_adapter.py
@@ -1,0 +1,198 @@
+"""
+Tests for the EvdevWakeAdapter.
+
+The evdev library is Linux-only; these tests guard on it with importorskip and
+exercise the pure device-classification logic and the lifecycle with mocked
+evdev objects (#762).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from picframe.infrastructure.os.evdev_wake_adapter import (
+    _EV_KEY,
+    _EV_REL,
+    _REL_X,
+    _REL_Y,
+    EvdevWakeAdapter,
+)
+
+
+def _event(etype: int, code: int, value: int) -> SimpleNamespace:
+    return SimpleNamespace(type=etype, code=code, value=value)
+
+
+def test_classify_mouse_motion() -> None:
+    assert EvdevWakeAdapter._classify(_event(_EV_REL, _REL_X, 1)) == "mouse"
+    assert EvdevWakeAdapter._classify(_event(_EV_REL, _REL_Y, -1)) == "mouse"
+
+
+def test_classify_keypress() -> None:
+    # KEY_A = 0x1e; value 1 = press.
+    assert EvdevWakeAdapter._classify(_event(_EV_KEY, 0x1E, 1)) == "keyboard"
+    # Key repeat (value 2) also wakes.
+    assert EvdevWakeAdapter._classify(_event(_EV_KEY, 0x1E, 2)) == "keyboard"
+
+
+def test_classify_ignores_key_release() -> None:
+    assert EvdevWakeAdapter._classify(_event(_EV_KEY, 0x1E, 0)) is None
+
+
+def test_classify_ignores_mouse_button() -> None:
+    # BTN_LEFT = 0x110 is outside the keyboard key range -> not a keyboard wake.
+    assert EvdevWakeAdapter._classify(_event(_EV_KEY, 0x110, 1)) is None
+
+
+def test_classify_ignores_other_event_types() -> None:
+    # EV_SYN = 0x00
+    assert EvdevWakeAdapter._classify(_event(0x00, 0x00, 0)) is None
+
+
+def test_is_wake_device_mouse() -> None:
+    device = MagicMock()
+    device.capabilities.return_value = {_EV_REL: [_REL_X, _REL_Y], _EV_KEY: [0x110]}
+    assert EvdevWakeAdapter._is_wake_device(device) is True
+
+
+def test_is_wake_device_keyboard() -> None:
+    device = MagicMock()
+    # Keyboard: only EV_KEY with standard keys, no REL, no BTN_TOUCH.
+    device.capabilities.return_value = {_EV_KEY: [0x01, 0x1E, 0x28]}
+    assert EvdevWakeAdapter._is_wake_device(device) is True
+
+
+def test_is_wake_device_excludes_touchscreen() -> None:
+    device = MagicMock()
+    # Touchscreen: EV_KEY with BTN_TOUCH and EV_ABS (no EV_REL).
+    device.capabilities.return_value = {_EV_KEY: [0x14A, 0x14B], 0x03: [0x00]}
+    assert EvdevWakeAdapter._is_wake_device(device) is False
+
+
+def test_is_wake_device_excludes_pure_button_device() -> None:
+    device = MagicMock()
+    # EV_KEY only with BTN_LEFT, no standard keys -> not wake-worthy.
+    device.capabilities.return_value = {_EV_KEY: [0x110]}
+    assert EvdevWakeAdapter._is_wake_device(device) is False
+
+
+def test_is_wake_device_handles_capability_error() -> None:
+    device = MagicMock()
+    device.capabilities.side_effect = OSError("boom")
+    assert EvdevWakeAdapter._is_wake_device(device) is False
+
+
+def test_register_callback_stores_callback() -> None:
+    adapter = EvdevWakeAdapter()
+    received: list[str] = []
+    adapter.register_callback(received.append)
+    # Invoke via the stored reference to confirm wiring.
+    assert adapter._callback is not None
+    adapter._callback("mouse")
+    assert received == ["mouse"]
+
+
+def test_is_available_false_when_no_input_dir() -> None:
+    with (
+        patch.dict("sys.modules", {"evdev": MagicMock()}),
+        patch("os.path.isdir", return_value=False),
+    ):
+        assert EvdevWakeAdapter.is_available() is False
+
+
+def test_is_available_true_when_readable_event_device() -> None:
+    with (
+        patch.dict("sys.modules", {"evdev": MagicMock()}),
+        patch("os.path.isdir", return_value=True),
+        patch("os.listdir", return_value=["event0", "mice"]),
+        patch("os.access", return_value=True),
+    ):
+        assert EvdevWakeAdapter.is_available() is True
+
+
+def test_is_available_false_when_no_event_devices() -> None:
+    with (
+        patch.dict("sys.modules", {"evdev": MagicMock()}),
+        patch("os.path.isdir", return_value=True),
+        patch("os.listdir", return_value=["mice", "by-path"]),
+        patch("os.access", return_value=True),
+    ):
+        assert EvdevWakeAdapter.is_available() is False
+
+
+def test_is_available_false_when_evdev_missing() -> None:
+    # evdev not installed: the bare `import evdev` raises ImportError.
+    with patch.dict("sys.modules", {"evdev": None}):
+        assert EvdevWakeAdapter.is_available() is False
+
+
+def test_start_open_and_listen_on_wake_device() -> None:
+    adapter = EvdevWakeAdapter()
+    fake_device = MagicMock()
+    fake_device.name = "Test Mouse"
+    fake_device.capabilities.return_value = {_EV_REL: [_REL_X, _REL_Y], _EV_KEY: [0x110]}
+
+    fake_evdev = MagicMock()
+    fake_evdev.InputDevice.return_value = fake_device
+    fake_device.read_loop.side_effect = OSError("device closed by test")
+
+    with (
+        patch("os.listdir", return_value=["event0"]),
+        patch("os.path.join", return_value="/dev/input/event0"),
+        patch.dict("sys.modules", {"evdev": fake_evdev}),
+    ):
+        adapter.start()
+
+    fake_evdev.InputDevice.assert_called_once_with("/dev/input/event0")
+    assert len(adapter._threads) == 1
+    assert adapter._started is True
+
+    adapter.stop()
+    fake_device.close.assert_called_once()
+    assert adapter._started is False
+
+
+def test_start_skips_non_wake_device() -> None:
+    adapter = EvdevWakeAdapter()
+    touch_device = MagicMock()
+    touch_device.name = "Touch"
+    touch_device.capabilities.return_value = {_EV_KEY: [0x14A]}
+
+    fake_evdev = MagicMock()
+    fake_evdev.InputDevice.return_value = touch_device
+
+    with (
+        patch("os.listdir", return_value=["event0"]),
+        patch("os.path.join", return_value="/dev/input/event0"),
+        patch.dict("sys.modules", {"evdev": fake_evdev}),
+    ):
+        adapter.start()
+
+    assert adapter._threads == []
+    assert adapter._started is True
+    adapter.stop()
+
+
+def test_start_logs_and_skips_unreadable_device() -> None:
+    adapter = EvdevWakeAdapter()
+    fake_evdev = MagicMock()
+    fake_evdev.InputDevice.side_effect = PermissionError("denied")
+
+    with (
+        patch("os.listdir", return_value=["event0"]),
+        patch("os.path.join", return_value="/dev/input/event0"),
+        patch.dict("sys.modules", {"evdev": fake_evdev}),
+    ):
+        adapter.start()
+
+    assert adapter._threads == []
+    assert adapter._started is True
+    adapter.stop()
+
+
+def test_start_noop_without_evdev() -> None:
+    adapter = EvdevWakeAdapter()
+    # Force the lazy `import evdev` inside start() to fail.
+    with patch.dict("sys.modules", {"evdev": None}):
+        adapter.start()
+    assert adapter._threads == []
+    assert adapter._started is False

--- a/test/infrastructure/os/test_hal_factory.py
+++ b/test/infrastructure/os/test_hal_factory.py
@@ -11,6 +11,7 @@ from picframe.infrastructure.os.mock_adapters import (
     MockDisplayPower,
     MockHardwareInput,
     MockSystemManager,
+    MockWakeInputListener,
 )
 
 
@@ -22,6 +23,7 @@ def test_hal_factory_darwin() -> None:
         assert isinstance(adapters.display_power, MockDisplayPower)
         assert isinstance(adapters.hardware_input, MockHardwareInput)
         assert isinstance(adapters.system_manager, MockSystemManager)
+        assert isinstance(adapters.wake_input, MockWakeInputListener)
 
 
 def test_hal_factory_win32() -> None:
@@ -32,6 +34,7 @@ def test_hal_factory_win32() -> None:
         assert isinstance(adapters.display_power, MockDisplayPower)
         assert isinstance(adapters.hardware_input, MockHardwareInput)
         assert isinstance(adapters.system_manager, MockSystemManager)
+        assert isinstance(adapters.wake_input, MockWakeInputListener)
 
 
 @patch("picframe.infrastructure.os.hal_factory.HALFactory._is_raspberry_pi", return_value=True)
@@ -53,6 +56,7 @@ def test_hal_factory_rpi_wayland_with_config(
         assert isinstance(adapters.display_power, WaylandDisplayPower)
         assert isinstance(adapters.hardware_input, RPiGPIOAdapter)
         assert isinstance(adapters.system_manager, LinuxSystemManager)
+        assert adapters.wake_input is not None
 
 
 @patch("picframe.infrastructure.os.hal_factory.HALFactory._is_raspberry_pi", return_value=True)
@@ -125,3 +129,36 @@ def test_is_raspberry_pi_detection() -> None:
     # Test file not found (e.g., standard Ubuntu VM)
     with patch("builtins.open", side_effect=FileNotFoundError):
         assert HALFactory._is_raspberry_pi() is False
+
+
+@patch(
+    "picframe.infrastructure.os.evdev_wake_adapter.EvdevWakeAdapter.is_available",
+    return_value=True,
+)
+def test_create_wake_input_listener_uses_evdev_when_available(
+    mock_available: Any,
+) -> None:
+    """On Linux with readable input devices, the factory injects EvdevWakeAdapter."""
+    from picframe.infrastructure.os.evdev_wake_adapter import EvdevWakeAdapter
+
+    with patch.object(sys, "platform", "linux"):
+        listener = HALFactory._create_wake_input_listener()
+        assert isinstance(listener, EvdevWakeAdapter)
+
+
+@patch(
+    "picframe.infrastructure.os.evdev_wake_adapter.EvdevWakeAdapter.is_available",
+    return_value=False,
+)
+def test_create_wake_input_listener_falls_back_to_mock(mock_available: Any) -> None:
+    """On Linux without readable input devices, the factory injects the mock."""
+    with patch.object(sys, "platform", "linux"):
+        listener = HALFactory._create_wake_input_listener()
+        assert isinstance(listener, MockWakeInputListener)
+
+
+def test_create_wake_input_listener_mock_on_non_linux() -> None:
+    """On non-Linux hosts the factory always injects the mock listener."""
+    with patch.object(sys, "platform", "darwin"):
+        listener = HALFactory._create_wake_input_listener()
+        assert isinstance(listener, MockWakeInputListener)


### PR DESCRIPTION
## Summary

Implements #762 — a backend hardware-input listener that wakes the display on **mouse-move / keypress** while the configured Wayland output is destroyed by `wlr-randr --off`. This is the wake-from-off half of the display-power UX agreed in #740: the surface-bound overlay can toggle the display **off**, but its layer-shell surface is destroyed when the output goes off, so its `pointerdown`/`keydown` listeners cannot fire to wake it back up.

This is **additive** to the existing GPIO/PIR `HardwareInputService` — a purpose-built path, not a reuse of the `input_id → Command` mapper.

## Design

- **New port** `IWakeInputListener` (`core/ports/hal.py`): a display-on-gate + debounce + input-class-gating listener, deliberately *not* the generic `IHardwareInput` mapper. Exported from `core/ports/__init__.py`.
- **`EvdevWakeAdapter`** (`infrastructure/os/evdev_wake_adapter.py`): implements the port using the `evdev` library (lazy-imported). It listens **passively** (no `grab()`), so the compositor keeps receiving events for normal UI while the display is on. Capability introspection filters to **pointer + keyboard** devices (touch excluded by design — the surface is destroyed while off, and touch-on-a-dark-screen is not a wake gesture). Emits `"mouse"` on relative pointer motion and `"keyboard"` on key press/repeat (releases ignored). `is_available()` probes readable `/dev/input/event*`; degrades gracefully (logs + skips) on unreadable devices.
- **`WakeOnInputService`** (`core/services/wake_on_input.py`): turns raw events into `Command.DISPLAY_ON` on the event bus. Gated by:
  - **`overlay.enabled_input_types`** — only `mouse`/`keyboard` wake; `touch` never wakes (enforced in the service even if a future adapter emitted it). Disabling both from the web UI disables wake live (reload on `CONFIG_CHANGED` whose `updated_sections` contains `"overlay"`). **No new config key.**
  - **Current display state** — idempotent: `IDisplayPower.is_on()` is checked first, so an already-on display is never re-woken.
  - **1 s cooldown debounce** — a burst of mouse moves while the display transitions on publishes at most one `DISPLAY_ON`.
  - Publishes **only `DISPLAY_ON`** — the `PLAY` side-effect stays owned by `DisplayPowerManager`.
- **`MockWakeInputListener`** + `simulate_event()` test hook in `mock_adapters.py`.
- **Wiring:** `HALAdapters.wake_input` added in `hal_factory.py` (evdev on Linux when available, mock otherwise); constructed/started/stopped in `main.py` (gated on `wake_input is not None`).
- **Dependency:** `evdev>=1.6.0` added with a Linux-only environment marker (`sys_platform == 'linux'`) so cross-platform `pip install` keeps working; lazy-imported so non-Linux runtime is unaffected.

## Acceptance criteria mapping (#762)

- [x] Wakes the display on **keypress** while the output is off.
- [x] Wakes the display on **mouse-move** while the output is off (debounced — 1 s cooldown).
- [x] Gated by `overlay.enabled_input_types` (mouse/keyboard); **touch does not wake** (excluded by design, asserted in `test_wake_on_input_touch_never_wakes`).
- [x] Publishes `Command.DISPLAY_ON` — the same command channel the Remote tab uses, handled by `DisplayPowerManager`.
- [x] Idempotent: no `DISPLAY_ON` when already on (`test_wake_on_input_noop_when_display_already_on`); no duplicate `PLAY`/`PAUSE` — the listener publishes only the power command (`test_wake_on_input_never_publishes_play`).
- [x] Reads raw `evdev` events independent of any Wayland surface (works with the output destroyed).
- [x] GPIO/PIR `HardwareInputService` path unchanged — fully additive.
- [x] pytest, mypy strict, ruff pass.

## Tests

- `test/core/services/test_wake_on_input.py` (12): gating, debounce, idempotency, touch-exclusion, never-PLAY, config-change reload, lifecycle.
- `test/infrastructure/os/test_evdev_wake_adapter.py` (19): event classification, device-class filtering (mouse/keyboard/touch/button-exclusion), `is_available` probe, start/stop lifecycle with mocked evdev, graceful skip of unreadable/non-wake devices.
- `test/infrastructure/os/test_hal_factory.py` (+3): wake-listener selection (evdev-when-available / mock fallback / non-Linux mock).

## Docs

- `docs/dev/architecture/overlay.md`: new "Wake-on-input while the output is off (#762)" subsection.
- `docs/user/overlay.md`: user-facing note on waking a powered-off display + `input` group.
- `docs/user/install_picframe.sh`: clarified the existing `input` group `usermod` line (already added the group; comment now names the #762 use).

## Operational note

The picframe user must be in the `input` group for `/dev/input/event*` access — the install script already adds this (`usermod -aG input`). The adapter degrades gracefully if a device is unreadable.

## Quality gates

- `pytest` (new/affected): 41 passed.
- `mypy src/picframe` (strict): no issues (91 files).
- `ruff check .` / `ruff format --check .`: clean.

Closes #762.

## Summary by Sourcery

Enable the display to wake from mouse or keyboard input even when its Wayland output and overlay surface are powered off.

New Features:
- Add backend wake-on-input support that turns mouse movement and keyboard activity into display wake commands while the Wayland output is off.
- Honor existing overlay input settings and support live enablement changes without introducing new configuration.

Bug Fixes:
- Allow displays whose Wayland surface has been destroyed during power-off to wake from hardware input.

Enhancements:
- Keep wake handling separate from GPIO/PIR command mapping and preserve display-power ownership of playback side effects.
- Filter wake input to pointer and keyboard devices, exclude touch and button-only devices, debounce bursts, and degrade gracefully when evdev devices are unavailable.

Build:
- Add the Linux-only evdev runtime dependency.

Deployment:
- Wire evdev or mock wake listeners into HAL creation and application lifecycle management.
- Document the required input-group access for reading Linux event devices.

Documentation:
- Document backend wake-on-input behavior in the overlay architecture and user guide.
- Clarify the installer’s existing input-group setup for evdev access.

Tests:
- Add coverage for wake-service gating, idempotency, debounce, configuration reload, lifecycle, event classification, device filtering, availability probing, fallback selection, and graceful error handling.