### PR TITLE
fix(overlay): replay cached on-screen visibility on browser connect (#771)

### DIFF
--- a/docs/dev/architecture/overlay.md
+++ b/docs/dev/architecture/overlay.md
@@ -223,10 +223,14 @@ them in sync:
   staying in the persisted set, and tapping it still collapses (removes from
   config), matching the dock.
 
-**Known limitation:** a fresh browser connect while plugins are auto-hidden
-falls back to `visible_plugins` (`onScreenPlugins === null` → assume shown)
-until the next hide/wake event; caching the latest on-screen set for
-`REQUEST_STATE` is out of scope.
+**Fresh-connect replay:** the `WebKitOverlayRenderer` caches the last
+`OnScreenPluginsChangedEvent` on-screen set (lock-guarded). On
+`CommandEvent(REQUEST_STATE)` — published by `/ws/state` on every fresh
+browser connect — it replays the cached set as `OverlayVisibilityChangedEvent`
+so the Remote tab's `onScreenPlugins` is seeded with the real (possibly
+auto-hidden) state instead of falling back to `visible_plugins` (assume shown).
+Before this a fresh connect while a panel was auto-hidden left its tile
+highlighted until the next hide/wake event.
 
 ## 6. Plugin manifest & loader
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -80,9 +80,13 @@ handles the `OverlayVisibilityChangedEvent` branch; `OverlayPanel.vue`
 tile de-highlights but still taps to collapse, matching the dock). Tests added
 for IPC round-trip/coercion, worker bridge handler, renderer republish, and WS
 serialization + ASGI subscription. Docs updated in `overlay.md`. All gates
-green. **Known limitation:** fresh browser connect while plugins auto-hidden
-falls back to `visible_plugins` until the next hide/wake event; caching the
-latest on-screen set for `REQUEST_STATE` is out of scope.
+green. **#766 fresh-connect replay (done):** the renderer caches the last
+`OnScreenPluginsChangedEvent` on-screen set and, on
+`CommandEvent(REQUEST_STATE)` (fresh browser connect), replays it as
+`OverlayVisibilityChangedEvent` so the Remote tab's `onScreenPlugins` is
+seeded with the real (possibly auto-hidden) state instead of falling back to
+`visible_plugins`. Previously a fresh connect while a panel was auto-hidden
+showed its tile highlighted until the next hide/wake event.
 
 **#765 follow-up — dock→browser live-sync (done):** the `/ws/state` WebSocket
 endpoint never subscribed to `OverlayConfigChangedEvent`, so a browser's

--- a/src/picframe/core/renderers/webkit_overlay_renderer.py
+++ b/src/picframe/core/renderers/webkit_overlay_renderer.py
@@ -709,6 +709,14 @@ class WebKitOverlayRenderer(IOverlayController):
 
     def _cleanup(self) -> None:
         self._running = False
+        # Clear the cached on-screen set so a restarted worker (display power
+        # cycle or recovery) uses the documented ``None`` fallback until it
+        # reports fresh runtime visibility. Otherwise a ``REQUEST_STATE`` from
+        # a freshly-connected browser replays the *previous* worker's stale
+        # set, which can disagree with the new worker's initial boot state
+        # (#771 review).
+        with self._on_screen_lock:
+            self._last_on_screen_plugins = None
         if self._conn:
             try:
                 self._conn.close()

--- a/src/picframe/core/renderers/webkit_overlay_renderer.py
+++ b/src/picframe/core/renderers/webkit_overlay_renderer.py
@@ -285,6 +285,14 @@ class WebKitOverlayRenderer(IOverlayController):
         # check-and-set of ``_restarting``; ``_restarting`` prevents re-entrancy.
         self._restart_lock = threading.Lock()
         self._restarting = False
+        # Last on-screen (runtime) plugin set reported by the worker (#766).
+        # Cached so a fresh browser connect (``CommandEvent(REQUEST_STATE)``)
+        # can replay the current on-screen visibility — otherwise the Remote
+        # tab falls back to the persisted ``visible_plugins`` set and its tile
+        # highlights stay lit while the dock icon correctly de-activates during
+        # auto-hide. ``None`` = no on-screen event seen yet this run.
+        self._last_on_screen_plugins: tuple[str, ...] | None = None
+        self._on_screen_lock = threading.Lock()
 
     # --- IOverlayController ---
 
@@ -518,7 +526,12 @@ class WebKitOverlayRenderer(IOverlayController):
             # ``OverlayVisibilityChangedEvent`` domain event the ``/ws/state``
             # endpoint forwards to browsers, so the Remote tile highlights
             # mirror the on-screen state instead of the persisted
-            # ``visible_plugins`` set.
+            # ``visible_plugins`` set. Cache the set so a fresh browser connect
+            # (``CommandEvent(REQUEST_STATE)``) can replay the current on-screen
+            # state instead of falling back to ``visible_plugins`` (assume shown)
+            # while a panel is auto-hidden.
+            with self._on_screen_lock:
+                self._last_on_screen_plugins = event.on_screen_plugins
             self._publisher.publish(
                 OverlayVisibilityChangedEvent(on_screen_plugins=event.on_screen_plugins)
             )
@@ -539,6 +552,27 @@ class WebKitOverlayRenderer(IOverlayController):
                 getattr(cmd, "type", type(cmd).__name__),
             )
 
+    def _on_command_event(self, event: CommandEvent) -> None:
+        """Replay the cached on-screen overlay visibility on a state request.
+
+        A fresh browser connect publishes ``CommandEvent(REQUEST_STATE)`` so
+        the playback engine republishes its state/media. The overlay's
+        on-screen visibility has no "engine" to republish it, so this handler
+        replays the last on-screen set cached from the worker
+        (``OnScreenPluginsChangedEvent``). Without this the Remote tab's
+        ``onScreenPlugins`` stays ``null`` and its tile highlights fall back to
+        the persisted ``visible_plugins`` set (assume shown) while the dock
+        icon correctly de-activates during auto-hide (#766). Republishing to all
+        subscribers is idempotent for already-connected browsers (they re-apply
+        the same set).
+        """
+        if event.command != Command.REQUEST_STATE:
+            return
+        with self._on_screen_lock:
+            cached = self._last_on_screen_plugins
+        if cached is not None:
+            self._publisher.publish(OverlayVisibilityChangedEvent(on_screen_plugins=cached))
+
     # --- Event subscriptions ---
 
     def _subscribe_events(self) -> None:
@@ -547,6 +581,7 @@ class WebKitOverlayRenderer(IOverlayController):
         self._subscriber.subscribe(DisplayPowerEvent, self._on_display_power_event)
         self._subscriber.subscribe(RendererConfigUpdatedEvent, self._on_renderer_config_updated)
         self._subscriber.subscribe(CurrentMediaChangedEvent, self._on_media_changed)
+        self._subscriber.subscribe(CommandEvent, self._on_command_event)
         self._subscribed = True
 
     def _unsubscribe_events(self) -> None:
@@ -558,6 +593,7 @@ class WebKitOverlayRenderer(IOverlayController):
                 RendererConfigUpdatedEvent, self._on_renderer_config_updated
             )
             self._subscriber.unsubscribe(CurrentMediaChangedEvent, self._on_media_changed)
+            self._subscriber.unsubscribe(CommandEvent, self._on_command_event)
             self._subscribed = False
 
     def _on_overlay_config_changed(self, event: OverlayConfigChangedEvent) -> None:

--- a/test/core/renderers/test_webkit_overlay_renderer.py
+++ b/test/core/renderers/test_webkit_overlay_renderer.py
@@ -368,6 +368,30 @@ def test_request_state_ignores_non_request_state_commands(
     mock_publisher.publish.assert_not_called()
 
 
+def test_cleanup_clears_on_screen_cache_so_restart_uses_fallback(
+    mock_publisher: MagicMock,
+    mock_subscriber: MagicMock,
+    plugin_loader: PluginLoader,
+    tmp_path,
+) -> None:
+    """``_cleanup`` (called by ``stop()`` and the display-power-on respawn)
+    clears the cached on-screen set so a restarted worker replays nothing on
+    the next ``REQUEST_STATE`` until it reports fresh runtime visibility.
+
+    Without this, a browser connecting during the post-restart window — before
+    the new worker emits its first ``OnScreenPluginsChangedEvent`` — would
+    receive the *previous* worker's stale set, which can disagree with the new
+    worker's initial boot state (#771 review)."""
+    renderer = make_renderer(mock_publisher, mock_subscriber, plugin_loader, tmp_path)
+    renderer._handle_event(OnScreenPluginsChangedEvent(on_screen_plugins=("clock", "text")))
+    assert renderer._last_on_screen_plugins is not None
+    renderer._cleanup()
+    assert renderer._last_on_screen_plugins is None
+    mock_publisher.publish.reset_mock()
+    renderer._on_command_event(CommandEvent(command=Command.REQUEST_STATE))
+    mock_publisher.publish.assert_not_called()
+
+
 def test_render_command_promote_sets_opacity_zero(
     mock_publisher: MagicMock,
     mock_subscriber: MagicMock,

--- a/test/core/renderers/test_webkit_overlay_renderer.py
+++ b/test/core/renderers/test_webkit_overlay_renderer.py
@@ -118,6 +118,7 @@ def test_start_spawns_worker_and_applies_initial_config(
     assert OverlayConfigChangedEvent in subscribed_types
     assert RenderCommand in subscribed_types
     assert CurrentMediaChangedEvent in subscribed_types
+    assert CommandEvent in subscribed_types
     sent = mock_client.return_value.send.call_args_list[-1][0][0]
     assert '"type": "set_config"' in sent
 
@@ -293,6 +294,78 @@ def test_handle_on_screen_plugins_changed_empty_publishes_empty_tuple(
     event = mock_publisher.publish.call_args[0][0]
     assert isinstance(event, OverlayVisibilityChangedEvent)
     assert event.on_screen_plugins == ()
+
+
+def test_request_state_replays_cached_on_screen_visibility(
+    mock_publisher: MagicMock,
+    mock_subscriber: MagicMock,
+    plugin_loader: PluginLoader,
+    tmp_path,
+) -> None:
+    """A fresh browser connect publishes ``CommandEvent(REQUEST_STATE)``; the
+    renderer replays the last on-screen set cached from the worker so the
+    Remote tab's ``onScreenPlugins`` is seeded with the real (possibly
+    auto-hidden) state instead of falling back to ``visible_plugins``
+    (assume shown) (#766)."""
+    renderer = make_renderer(mock_publisher, mock_subscriber, plugin_loader, tmp_path)
+    # Worker reports the text panel auto-hidden (only clock on screen).
+    renderer._handle_event(OnScreenPluginsChangedEvent(on_screen_plugins=("clock",)))
+    mock_publisher.publish.reset_mock()
+    # A browser connects -> /ws/state publishes REQUEST_STATE.
+    renderer._on_command_event(CommandEvent(command=Command.REQUEST_STATE))
+    mock_publisher.publish.assert_called_once()
+    event = mock_publisher.publish.call_args[0][0]
+    assert isinstance(event, OverlayVisibilityChangedEvent)
+    assert event.on_screen_plugins == ("clock",)
+
+
+def test_request_state_replays_empty_on_screen_set(
+    mock_publisher: MagicMock,
+    mock_subscriber: MagicMock,
+    plugin_loader: PluginLoader,
+    tmp_path,
+) -> None:
+    """When every expanded plugin is auto-hidden the worker reports an empty
+    on-screen set; REQUEST_STATE must replay that empty set (not skip it) so
+    the Remote tab de-highlights all tiles instead of falling back to
+    ``visible_plugins``."""
+    renderer = make_renderer(mock_publisher, mock_subscriber, plugin_loader, tmp_path)
+    renderer._handle_event(OnScreenPluginsChangedEvent(on_screen_plugins=()))
+    mock_publisher.publish.reset_mock()
+    renderer._on_command_event(CommandEvent(command=Command.REQUEST_STATE))
+    mock_publisher.publish.assert_called_once()
+    event = mock_publisher.publish.call_args[0][0]
+    assert isinstance(event, OverlayVisibilityChangedEvent)
+    assert event.on_screen_plugins == ()
+
+
+def test_request_state_without_cache_publishes_nothing(
+    mock_publisher: MagicMock,
+    mock_subscriber: MagicMock,
+    plugin_loader: PluginLoader,
+    tmp_path,
+) -> None:
+    """Before the worker has reported any on-screen change (e.g. overlay just
+    started) the cache is ``None``; REQUEST_STATE replays nothing so the Remote
+    tab keeps its ``null`` -> ``visible_plugins`` fallback."""
+    renderer = make_renderer(mock_publisher, mock_subscriber, plugin_loader, tmp_path)
+    renderer._on_command_event(CommandEvent(command=Command.REQUEST_STATE))
+    mock_publisher.publish.assert_not_called()
+
+
+def test_request_state_ignores_non_request_state_commands(
+    mock_publisher: MagicMock,
+    mock_subscriber: MagicMock,
+    plugin_loader: PluginLoader,
+    tmp_path,
+) -> None:
+    """Only ``REQUEST_STATE`` triggers a replay; other commands (NEXT, PREV,
+    SET_CONFIG, ...) must not republish visibility noise on every keystroke."""
+    renderer = make_renderer(mock_publisher, mock_subscriber, plugin_loader, tmp_path)
+    renderer._handle_event(OnScreenPluginsChangedEvent(on_screen_plugins=("clock",)))
+    mock_publisher.publish.reset_mock()
+    renderer._on_command_event(CommandEvent(command=Command.NEXT))
+    mock_publisher.publish.assert_not_called()
 
 
 def test_render_command_promote_sets_opacity_zero(


### PR DESCRIPTION
## Summary

Fixes #771 — the Remote tab overlay plugin tiles showed the wrong state on browser reload: an auto-hidden panel (e.g. Photo Caption) appeared highlighted/active right after reload, and only corrected after clicking the tile once.

## Root cause

This was a documented known limitation of the #766 on-screen visibility channel:

- The touch overlay reports runtime on-screen visibility via `OnScreenPluginsChangedEvent` → `OverlayVisibilityChangedEvent`, forwarded to browsers over `/ws/state` so Remote tile highlights mirror the dock icon during auto-hide/wake fades.
- That event is only published when the on-screen set **changes**. On a fresh browser connect the on-screen state is *stable* (not changing), so no `OverlayVisibilityChangedEvent` is delivered.
- The frontend's `onScreenPlugins` ref therefore stays `null` and `OverlayPanel.vue`'s `isActive()` falls back to the persisted `visible_plugins` set (assume shown) → tiles stay highlighted even while the panel is auto-hidden.
- The first hide/wake/toggle event (or a manual tile tap, which writes `visible_plugins` and triggers a visibility event) corrects the state — exactly the "click to sync" symptom reported.

## Fix

Cache the latest on-screen set in `WebKitOverlayRenderer` (lock-guarded) and replay it on `CommandEvent(REQUEST_STATE)` — which `/ws/state` publishes on every fresh browser connect — as an `OverlayVisibilityChangedEvent`. This seeds the Remote tab's `onScreenPlugins` with the real (possibly auto-hidden) state immediately on connect, instead of falling back to `visible_plugins`.

- Republishing to all subscribers is **idempotent** for already-connected browsers (they re-apply the same set).
- The `null` → `visible_plugins` fallback in the frontend is preserved as a belt-and-suspenders path for the edge case where no on-screen event has been seen yet this run (e.g. overlay just started).
- **Backend-only** — no frontend bundle change required.

## Changes

- `src/picframe/core/renderers/webkit_overlay_renderer.py`:
  - `__init__`: add `_last_on_screen_plugins: tuple[str, ...] | None` + `_on_screen_lock`.
  - `_handle_event` (`OnScreenPluginsChangedEvent`): cache the set under the lock before publishing.
  - New `_on_command_event`: on `Command.REQUEST_STATE`, replay the cached set as `OverlayVisibilityChangedEvent`. Subscribed/unsubscribed in `_subscribe_events`/`_unsubscribe_events`.
- `test/core/renderers/test_webkit_overlay_renderer.py`: 4 new tests (replay cached set, replay empty set, no cache → no publish, non-REQUEST_STATE commands ignored) + `CommandEvent` added to the start-subscription assertion.
- `docs/dev/architecture/overlay.md` + `memory-bank/activeContext.md`: the "known limitation" notes are updated to record the fresh-connect replay.

## Verification

- `pytest test/core/renderers/test_webkit_overlay_renderer.py` — 45 passed (+4 new)
- `pytest test/core/renderers/test_webkit_overlay_renderer.py test/api/test_app.py` — 134 passed
- `pytest test/infrastructure/overlay test/core/services/test_config_service.py test/core/renderers` — 474 passed
- `ruff format` / `ruff check` — clean
- `mypy src/picframe/core/renderers/webkit_overlay_renderer.py` — no issues

## Summary by Sourcery

Replay the latest runtime overlay visibility when browsers request state so Remote tile highlights are synchronized immediately after reconnecting.

Bug Fixes:
- Ensure Remote overlay tiles reflect the actual on-screen visibility immediately after a browser reconnect, including auto-hidden and empty plugin states.

Enhancements:
- Cache runtime overlay visibility and replay it on state requests while clearing stale data when the worker restarts.

Documentation:
- Document the fresh-connect visibility replay behavior and replace the previous known limitation.

Tests:
- Add coverage for cached visibility replay, empty and uncached states, ignored commands, subscription changes, and cache clearing during cleanup.